### PR TITLE
Revise date formatting

### DIFF
--- a/src/cellrenderer.ts
+++ b/src/cellrenderer.ts
@@ -266,7 +266,7 @@ class TextRendererView extends CellRendererView {
           formatted_value = String(config.value);
         } else {
           if (this.model.get('format_type') == 'time') {
-            formatted_value = String(d3TimeFormat.format(formatting_rule)(config.value));
+            formatted_value = String(d3TimeFormat.timeFormat(formatting_rule)(new Date(config.value)));
           } else {
             formatted_value = String(d3Format.format(formatting_rule)(config.value));
           }


### PR DESCRIPTION
Just a quick fix (`.format()` -> `.timeFormat()`), as I noted that the datetime formatting was resulting in blank values. It also looks like a `Date()` object is needed to operate on. Ordinarily, I would think that the `Date()` constructor would be a bit risky here, but the data model only accepts data that follows the JSON Table Schema, so any values identified as dates in the schema should be a ISO8601 format string.

```
from ipydatagrid import DataGrid, TextRenderer
import pandas as pd
import numpy as np
import json

df = pd.DataFrame({
    'Value 1': np.random.randn(5),
    'Value 2': np.random.randn(5),
    'Dates': pd.date_range(end=pd.Timestamp('today'), periods=5)
})
jsontable = json.loads(df.to_json(orient='table'))

renderers = {
    'Dates': TextRenderer(
        format='%Y/%m/%d',
        format_type='time'
    ),
}

DataGrid(data=jsontable, base_column_size=150, renderers=renderers)
```
![Screen Shot 2019-08-28 at 3 09 46 PM](https://user-images.githubusercontent.com/26637211/63896517-13c66000-c9a7-11e9-8e2e-c1fe6e1b5d47.png)
