### PR TITLE
Add support for date scales

### DIFF
--- a/src/cellrenderer.ts
+++ b/src/cellrenderer.ts
@@ -179,7 +179,7 @@ abstract class CellRendererView extends WidgetView {
     }
 
     // If it's a DateScale, convert the value to a Date object
-    if (processor.model.type == 'date') {
+    if (processor.model.type == 'date' || processor.model.type == 'date_color_linear') {
       return processor.scale(new Date(config.value));
     }
 


### PR DESCRIPTION
If the scale is a Date Scale, we need to convert the cell value to a Date object before calling the scale function.

![datescale](https://user-images.githubusercontent.com/21197331/63920280-c39bdc00-ca40-11e9-86e5-55034ae5a1ea.png)
