### PR TITLE
Link selection between views

### DIFF
--- a/src/datagrid.ts
+++ b/src/datagrid.ts
@@ -106,6 +106,8 @@ export
       this.save_changes();
     });
 
+    this.selectionModel = new BasicSelectionModel({ model: this.data_model });
+
     this.updateTransforms();
   }
 
@@ -129,6 +131,7 @@ export
   static view_module_version = MODULE_VERSION;
 
   data_model: ViewBasedJSONModel;
+  selectionModel: BasicSelectionModel;
 }
 
 class IIPyDataGridMouseHandler extends BasicMouseHandler {
@@ -216,11 +219,12 @@ class DataGridView extends DOMWidgetView {
       this.grid.model = this.model.data_model;
       this.grid.keyHandler = new BasicKeyHandler();
       this.grid.mouseHandler = new IIPyDataGridMouseHandler(this);
-      this.grid.selectionModel = new BasicSelectionModel({ model: this.model.data_model });
+      this.grid.selectionModel = this.model.selectionModel;
       this.updateGridRenderers();
 
       this.model.on('change:data', () => {
         this.grid.model = this.model.data_model;
+        this.grid.selectionModel = this.model.selectionModel;
       });
 
       this.model.on('change:base_row_size', () => {


### PR DESCRIPTION
The selection model is now part of the Widget model, this allows synchronizing the selection between views. And it will allow us to then synchronize it with Python.

![selection_link](https://user-images.githubusercontent.com/21197331/64601621-8c70e780-d3bd-11e9-8b0c-a52eaee10344.gif)
