### PR TITLE
Update filter menu on data change

### DIFF
--- a/src/core/filterMenu.ts
+++ b/src/core/filterMenu.ts
@@ -642,6 +642,20 @@ export class InteractiveFilterDialog extends Widget {
     ]
   }
 
+  /**
+   * Returns a reference to the data model used for this menu.
+   */
+  get model(): ViewBasedJSONModel {
+    return this._model;
+  }
+
+  /**
+   * Updates the data model used for this menu.
+   */
+  set model(model: ViewBasedJSONModel) {
+    this._model = model;
+  }
+
   private _model: ViewBasedJSONModel;
 
   // DOM elements

--- a/src/datagrid.ts
+++ b/src/datagrid.ts
@@ -225,6 +225,7 @@ class DataGridView extends DOMWidgetView {
       this.model.on('change:data', () => {
         this.grid.model = this.model.data_model;
         this.grid.selectionModel = this.model.selectionModel;
+        this.filterDialog.model = this.model.data_model;
       });
 
       this.model.on('change:base_row_size', () => {


### PR DESCRIPTION
When a new data model is created due to a change in data on the widget side, we also need to set that new data model on the filter menu so that the correct values will be displayed on the "Filter by Value" option.