### PR TITLE
Add region parameter to .uniqueValues()

### DIFF
--- a/src/core/filterMenu.ts
+++ b/src/core/filterMenu.ts
@@ -399,7 +399,10 @@ export class InteractiveFilterDialog extends Widget {
    * Creates a `VirtualElement` to display the unique values of a column.
    */
   protected createUniqueValueNodes(): VirtualElement {
-    const uniqueVals = this._model.uniqueValues(this._columnIndex);
+    const uniqueVals = this._model.uniqueValues(
+      this._region,
+      this._columnIndex
+    );
     const optionElems = uniqueVals.map(val => {
       return h.option({ value: val }, String(val))
     });

--- a/src/core/view.ts
+++ b/src/core/view.ts
@@ -137,8 +137,8 @@ class View {
    *
    * @param columnIndex - The index to retrieve unique values for.
    */
-  uniqueValues(columnIndex: number): any[]{
-    let columnName = this.metadata('body', columnIndex)['name'];
+  uniqueValues(region: DataModel.CellRegion, columnIndex: number): any[]{
+    let columnName = this.metadata(region, columnIndex)['name'];
     let uniqueVals = new Set();
     for (let row of this._data) {
       uniqueVals.add(row[columnName]);

--- a/src/core/viewbasedjsonmodel.ts
+++ b/src/core/viewbasedjsonmodel.ts
@@ -162,8 +162,8 @@ export class ViewBasedJSONModel extends DataModel {
    * 
    * @param columnIndex - The index to retrieve unique values for.
    */
-  uniqueValues(columnIndex: number): any[] {
-    return this.currentView.uniqueValues(columnIndex);
+  uniqueValues(region: DataModel.CellRegion, columnIndex: number): any[] {
+    return this.currentView.uniqueValues(region, columnIndex);
   }
 
   get transformStateChanged(): ISignal<this, TransformStateManager.IEvent> {

--- a/src/tests/view.test.ts
+++ b/src/tests/view.test.ts
@@ -80,6 +80,25 @@ describe('Test .data()', () => {
   })
 });
 
+describe('Test .uniqueValues()', () => {
+  const testData = DataGenerator.multiCol({
+    length: 5, data: [
+      { name: 'string', type: 'string', data: ['A', 'C', 'B', 'A', 'C'] },
+      { name: 'boolean', type: 'boolean', data: [true, false, true, false, false] },
+    ]
+  });
+  const testView = new View(testData)
+  test('cellregion-column-header-0', () => {
+    expect(testView.uniqueValues('column-header', 0)).toEqual(['A', 'C', 'B'])
+  });
+  test('cellregion-column-header-1', () => {
+    expect(testView.uniqueValues('column-header', 1)).toEqual([true, false])
+  });
+  test('cellregion-corner-header-0', () => {
+    expect(testView.uniqueValues('corner-header', 0)).toEqual([0, 1, 2, 3, 4])
+  });
+})
+
 /**
  * The namespace for the module implementation details.
  */


### PR DESCRIPTION
Adds the `region` parameter to `.uniqueValues()` so that interactive filtering by value on primary key fields will work as intended.