### PR TITLE
Fix MANIFEST.in file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,26 +2,14 @@ include LICENSE.txt
 include README.md
 
 include setupbase.py
-include pytest.ini
-include .coverage.rc
 
 include package.json
+include tsconfig.json
 include webpack.config.js
 include ipydatagrid/labextension/*.tgz
 
-# Documentation
-graft docs
-exclude docs/\#*
-prune docs/build
-prune docs/gh-pages
-prune docs/dist
-
 # Examples
 graft examples
-
-# Tests
-graft tests
-prune tests/build
 
 # Javascript files
 graft ipydatagrid/nbextension


### PR DESCRIPTION
This file should contain the `tsconfig.json` for the conda recipe to
build correctly. It also contained unexisting files.