### PR TITLE
Only allow 1 sort transform

### DIFF
--- a/src/core/transformStateManager.ts
+++ b/src/core/transformStateManager.ts
@@ -43,6 +43,11 @@ export class TransformStateManager {
     // Add the transform to the state
     switch (transform.type) {
       case ('sort'):
+        // Only allow one sort transform.
+        // TODO: Support multiple sort columns.
+        for (let key of Object.keys(this._state)) {
+          this._state[key]['sort'] = undefined;
+        }
         this._state[transform.columnIndex]['sort'] = transform;
         break;
       case ('filter'):


### PR DESCRIPTION
 - Only allow 1 sort transform. If multiple sorts are present, they are executed in order by column, which is likely to be undesired until multiple column sorting is supported.