### PR TITLE
Remove selectionModel.clear() before assigning new selectionModel

### DIFF
--- a/src/datagrid.ts
+++ b/src/datagrid.ts
@@ -186,10 +186,6 @@ export
   }
 
   updateSelectionModel() {
-    if (this.selectionModel) {
-      this.selectionModel.clear();
-    }
-
     const selectionMode = this.get('selection_mode');
 
     if (selectionMode === 'none') {


### PR DESCRIPTION
Noted this while working on tests. Do we need the `SelectionModel` to be cleared here? It appears that we always create a new model, but I wasn't sure if the signal emitted on `BasicSelectionModel.clear()` is needed somewhere else?