### PR TITLE
Update view data model with trigger

### DIFF
--- a/src/datagrid.ts
+++ b/src/datagrid.ts
@@ -175,6 +175,7 @@ export
     })
 
     this.updateTransforms();
+    this.trigger('data-model-changed');
     this.updateSelectionModel();
   }
 
@@ -319,7 +320,7 @@ class DataGridView extends DOMWidgetView {
       this.grid.selectionModel = this.model.selectionModel;
       this.updateGridRenderers();
 
-      this.model.on('change:data', () => {
+      this.model.on('data-model-changed', () => {
         this.grid.model = this.model.data_model;
         this.updateHeaderRenderer();
         this.filterDialog.model = this.model.data_model;


### PR DESCRIPTION
Quick change to `DataGridView` to update the grid's data model in response to a trigger from `DataGridModel` instead of the initial state change in the model. This should prevent a `BasicSelectionModel` with the new data model being assigned to a grid before the grid's data model has been updated.