### PR TITLE
Add datagrid widget tests

### DIFF
--- a/__mocks__/styleMock.js
+++ b/__mocks__/styleMock.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  "plugins": ["transform-es2015-modules-commonjs"],
+  "ignore": [
+    /\.css$/,
+    '\.css$'
+  ]
+};

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,6 +3,16 @@ module.exports = {
     "<rootDir>/src/tests"
   ],
   "transform": {
-    "^.+\\.tsx?$": "ts-jest"
+    "^.+\\.tsx?$": "ts-jest",
+    "^.+\\.js$": "babel-jest"
   },
+  "transformIgnorePatterns": [
+    "node_modules/?!(@jupyter-widgets)",
+  ],
+  "setupFiles": [
+    './src/tests/setupFile.js'
+  ],
+  "moduleNameMapper":{
+    "\\.(css|less)$": "<rootDir>/__mocks__/styleMock.js",
+}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,123 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@babel/cli": {
+      "version": "7.6.4",
+      "resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.6.4.tgz",
+      "integrity": "sha512-tqrDyvPryBM6xjIyKKUwr3s8CzmmYidwgdswd7Uc/Cv0ogZcuS1TYQTLx/eWKP3UbJ6JxZAiYlBZabXm/rtRsQ==",
+      "dev": true,
+      "requires": {
+        "chokidar": "^2.1.8",
+        "commander": "^2.8.1",
+        "convert-source-map": "^1.1.0",
+        "fs-readdir-recursive": "^1.1.0",
+        "glob": "^7.0.0",
+        "lodash": "^4.17.13",
+        "mkdirp": "^0.5.1",
+        "output-file-sync": "^2.0.0",
+        "slash": "^2.0.0",
+        "source-map": "^0.5.0"
+      },
+      "dependencies": {
+        "braces": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "arr-flatten": "^1.1.0",
+            "array-unique": "^0.3.2",
+            "extend-shallow": "^2.0.1",
+            "fill-range": "^4.0.0",
+            "isobject": "^3.0.1",
+            "repeat-element": "^1.1.2",
+            "snapdragon": "^0.8.1",
+            "snapdragon-node": "^2.0.1",
+            "split-string": "^3.0.2",
+            "to-regex": "^3.0.1"
+          }
+        },
+        "chokidar": {
+          "version": "2.1.8",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
+          "integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "anymatch": "^2.0.0",
+            "async-each": "^1.0.1",
+            "braces": "^2.3.2",
+            "fsevents": "^1.2.7",
+            "glob-parent": "^3.1.0",
+            "inherits": "^2.0.3",
+            "is-binary-path": "^1.0.0",
+            "is-glob": "^4.0.0",
+            "normalize-path": "^3.0.0",
+            "path-is-absolute": "^1.0.0",
+            "readdirp": "^2.2.1",
+            "upath": "^1.1.1"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        },
+        "fill-range": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "extend-shallow": "^2.0.1",
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1",
+            "to-regex-range": "^2.1.0"
+          }
+        },
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          }
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        },
+        "to-regex-range": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+          "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1"
+          }
+        }
+      }
+    },
     "@babel/code-frame": {
       "version": "7.5.5",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
@@ -14,31 +131,77 @@
       }
     },
     "@babel/core": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.6.0.tgz",
-      "integrity": "sha512-FuRhDRtsd6IptKpHXAa+4WPZYY2ZzgowkbLBecEDDSje1X/apG7jQM33or3NdOmjXBKWGOg4JmSiRfUfuTtHXw==",
+      "version": "7.6.3",
+      "resolved": "http://artprod.dev.bloomberg.com/artifactory/api/npm/npm-repos/@babel/core/-/core-7.6.3.tgz",
+      "integrity": "sha1-RN6CTonqoIm7EtpzN7yb3/KraPk=",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.5.5",
-        "@babel/generator": "^7.6.0",
-        "@babel/helpers": "^7.6.0",
-        "@babel/parser": "^7.6.0",
+        "@babel/generator": "^7.6.3",
+        "@babel/helpers": "^7.6.2",
+        "@babel/parser": "^7.6.3",
         "@babel/template": "^7.6.0",
-        "@babel/traverse": "^7.6.0",
-        "@babel/types": "^7.6.0",
+        "@babel/traverse": "^7.6.3",
+        "@babel/types": "^7.6.3",
         "convert-source-map": "^1.1.0",
         "debug": "^4.1.0",
         "json5": "^2.1.0",
         "lodash": "^4.17.13",
         "resolve": "^1.3.2",
         "semver": "^5.4.1",
-        "source-map": "^0.5.0"
+        "source-map": "^0.6.1"
       },
       "dependencies": {
+        "@babel/generator": {
+          "version": "7.6.3",
+          "resolved": "http://artprod.dev.bloomberg.com/artifactory/api/npm/npm-repos/@babel/generator/-/generator-7.6.3.tgz",
+          "integrity": "sha1-cdU3UmT5Pse6x9nzWmcGdzP1V44=",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.6.3",
+            "jsesc": "^2.5.1",
+            "lodash": "^4.17.13",
+            "source-map": "^0.6.1"
+          }
+        },
+        "@babel/parser": {
+          "version": "7.6.3",
+          "resolved": "http://artprod.dev.bloomberg.com/artifactory/api/npm/npm-repos/@babel/parser/-/parser-7.6.3.tgz",
+          "integrity": "sha1-nv+LnD7q4Wp02NT/MNor0NbwSH4=",
+          "dev": true
+        },
+        "@babel/traverse": {
+          "version": "7.6.3",
+          "resolved": "http://artprod.dev.bloomberg.com/artifactory/api/npm/npm-repos/@babel/traverse/-/traverse-7.6.3.tgz",
+          "integrity": "sha1-ZtfboUawhnA8D7EN1Yi3NkzsR/k=",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.5.5",
+            "@babel/generator": "^7.6.3",
+            "@babel/helper-function-name": "^7.1.0",
+            "@babel/helper-split-export-declaration": "^7.4.4",
+            "@babel/parser": "^7.6.3",
+            "@babel/types": "^7.6.3",
+            "debug": "^4.1.0",
+            "globals": "^11.1.0",
+            "lodash": "^4.17.13"
+          }
+        },
+        "@babel/types": {
+          "version": "7.6.3",
+          "resolved": "http://artprod.dev.bloomberg.com/artifactory/api/npm/npm-repos/@babel/types/-/types-7.6.3.tgz",
+          "integrity": "sha1-PwfZb4VPmOL71FxksMuULRHougk=",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.13",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
         "debug": {
           "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "resolved": "http://artprod.dev.bloomberg.com/artifactory/api/npm/npm-repos/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
           "dev": true,
           "requires": {
             "ms": "^2.1.1"
@@ -46,14 +209,8 @@
         },
         "ms": {
           "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "resolved": "http://artprod.dev.bloomberg.com/artifactory/api/npm/npm-repos/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
           "dev": true
         }
       }
@@ -79,6 +236,71 @@
         }
       }
     },
+    "@babel/helper-annotate-as-pure": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0.tgz",
+      "integrity": "sha512-3UYcJUj9kvSLbLbUIfQTqzcy5VX7GRZ/CCDrnOaZorFFM01aXp1+GJwuFGV4NDDoAS+mOUyHcO6UD/RfqOks3Q==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@babel/helper-builder-binary-assignment-operator-visitor": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.1.0.tgz",
+      "integrity": "sha512-qNSR4jrmJ8M1VMM9tibvyRAHXQs2PmaksQF7c1CGJNipfe3D8p+wgNwgso/P2A2r2mdgBWAXljNWR0QRZAMW8w==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-explode-assignable-expression": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@babel/helper-call-delegate": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.4.4.tgz",
+      "integrity": "sha512-l79boDFJ8S1c5hvQvG+rc+wHw6IuH7YldmRKsYtpbawsxURu/paVy57FZMomGK22/JckepaikOkY0MoAmdyOlQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-hoist-variables": "^7.4.4",
+        "@babel/traverse": "^7.4.4",
+        "@babel/types": "^7.4.4"
+      }
+    },
+    "@babel/helper-create-class-features-plugin": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.6.0.tgz",
+      "integrity": "sha512-O1QWBko4fzGju6VoVvrZg0RROCVifcLxiApnGP3OWfWzvxRZFCoBD81K5ur5e3bVY2Vf/5rIJm8cqPKn8HUJng==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-function-name": "^7.1.0",
+        "@babel/helper-member-expression-to-functions": "^7.5.5",
+        "@babel/helper-optimise-call-expression": "^7.0.0",
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/helper-replace-supers": "^7.5.5",
+        "@babel/helper-split-export-declaration": "^7.4.4"
+      }
+    },
+    "@babel/helper-define-map": {
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.5.5.tgz",
+      "integrity": "sha512-fTfxx7i0B5NJqvUOBBGREnrqbTxRh7zinBANpZXAVDlsZxYdclDp467G1sQ8VZYMnAURY3RpBUAgOYT9GfzHBg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-function-name": "^7.1.0",
+        "@babel/types": "^7.5.5",
+        "lodash": "^4.17.13"
+      }
+    },
+    "@babel/helper-explode-assignable-expression": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.1.0.tgz",
+      "integrity": "sha512-NRQpfHrJ1msCHtKjbzs9YcMmJZOg6mQMmGRB+hbamEdG5PNpaSm95275VD92DvJKuyl0s2sFiDmMZ+EnnvufqA==",
+      "dev": true,
+      "requires": {
+        "@babel/traverse": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
     "@babel/helper-function-name": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
@@ -99,11 +321,105 @@
         "@babel/types": "^7.0.0"
       }
     },
+    "@babel/helper-hoist-variables": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.4.4.tgz",
+      "integrity": "sha512-VYk2/H/BnYbZDDg39hr3t2kKyifAm1W6zHRfhx8jGjIHpQEBv9dry7oQ2f3+J703TLu69nYdxsovl0XYfcnK4w==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.4.4"
+      }
+    },
+    "@babel/helper-member-expression-to-functions": {
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.5.5.tgz",
+      "integrity": "sha512-5qZ3D1uMclSNqYcXqiHoA0meVdv+xUEex9em2fqMnrk/scphGlGgg66zjMrPJESPwrFJ6sbfFQYUSa0Mz7FabA==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.5.5"
+      }
+    },
+    "@babel/helper-module-imports": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.0.0.tgz",
+      "integrity": "sha512-aP/hlLq01DWNEiDg4Jn23i+CXxW/owM4WpDLFUbpjxe4NS3BhLVZQ5i7E0ZrxuQ/vwekIeciyamgB1UIYxxM6A==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@babel/helper-module-transforms": {
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.5.5.tgz",
+      "integrity": "sha512-jBeCvETKuJqeiaCdyaheF40aXnnU1+wkSiUs/IQg3tB85up1LyL8x77ClY8qJpuRJUcXQo+ZtdNESmZl4j56Pw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.0.0",
+        "@babel/helper-simple-access": "^7.1.0",
+        "@babel/helper-split-export-declaration": "^7.4.4",
+        "@babel/template": "^7.4.4",
+        "@babel/types": "^7.5.5",
+        "lodash": "^4.17.13"
+      }
+    },
+    "@babel/helper-optimise-call-expression": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.0.0.tgz",
+      "integrity": "sha512-u8nd9NQePYNQV8iPWu/pLLYBqZBa4ZaY1YWRFMuxrid94wKI1QNt67NEZ7GAe5Kc/0LLScbim05xZFWkAdrj9g==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.0.0"
+      }
+    },
     "@babel/helper-plugin-utils": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz",
       "integrity": "sha512-CYAOUCARwExnEixLdB6sDm2dIJ/YgEAKDM1MOeMeZu9Ld/bDgVo8aiWrXwcY7OBh+1Ea2uUcVRcxKk0GJvW7QA==",
       "dev": true
+    },
+    "@babel/helper-regex": {
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.5.5.tgz",
+      "integrity": "sha512-CkCYQLkfkiugbRDO8eZn6lRuR8kzZoGXCg3149iTk5se7g6qykSpy3+hELSwquhu+TgHn8nkLiBwHvNX8Hofcw==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.13"
+      }
+    },
+    "@babel/helper-remap-async-to-generator": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.1.0.tgz",
+      "integrity": "sha512-3fOK0L+Fdlg8S5al8u/hWE6vhufGSn0bN09xm2LXMy//REAF8kDCrYoOBKYmA8m5Nom+sV9LyLCwrFynA8/slg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-annotate-as-pure": "^7.0.0",
+        "@babel/helper-wrap-function": "^7.1.0",
+        "@babel/template": "^7.1.0",
+        "@babel/traverse": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@babel/helper-replace-supers": {
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.5.5.tgz",
+      "integrity": "sha512-XvRFWrNnlsow2u7jXDuH4jDDctkxbS7gXssrP4q2nUD606ukXHRvydj346wmNg+zAgpFx4MWf4+usfC93bElJg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-member-expression-to-functions": "^7.5.5",
+        "@babel/helper-optimise-call-expression": "^7.0.0",
+        "@babel/traverse": "^7.5.5",
+        "@babel/types": "^7.5.5"
+      }
+    },
+    "@babel/helper-simple-access": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.1.0.tgz",
+      "integrity": "sha512-Vk+78hNjRbsiu49zAPALxTb+JUQCz1aolpd8osOF16BGnLtseD21nbHgLPGUwrXEurZgiCOUmvs3ExTu4F5x6w==",
+      "dev": true,
+      "requires": {
+        "@babel/template": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
     },
     "@babel/helper-split-export-declaration": {
       "version": "7.4.4",
@@ -114,15 +430,105 @@
         "@babel/types": "^7.4.4"
       }
     },
+    "@babel/helper-wrap-function": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.2.0.tgz",
+      "integrity": "sha512-o9fP1BZLLSrYlxYEYyl2aS+Flun5gtjTIG8iln+XuEzQTs0PLagAGSXUcqruJwD5fM48jzIEggCKpIfWTcR7pQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-function-name": "^7.1.0",
+        "@babel/template": "^7.1.0",
+        "@babel/traverse": "^7.1.0",
+        "@babel/types": "^7.2.0"
+      }
+    },
     "@babel/helpers": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.6.0.tgz",
-      "integrity": "sha512-W9kao7OBleOjfXtFGgArGRX6eCP0UEcA2ZWEWNkJdRZnHhW4eEbeswbG3EwaRsnQUAEGWYgMq1HsIXuNNNy2eQ==",
+      "version": "7.6.2",
+      "resolved": "http://artprod.dev.bloomberg.com/artifactory/api/npm/npm-repos/@babel/helpers/-/helpers-7.6.2.tgz",
+      "integrity": "sha1-aB/+SJ6k3MVfI85GnljlnBwEUVM=",
       "dev": true,
       "requires": {
         "@babel/template": "^7.6.0",
-        "@babel/traverse": "^7.6.0",
+        "@babel/traverse": "^7.6.2",
         "@babel/types": "^7.6.0"
+      },
+      "dependencies": {
+        "@babel/generator": {
+          "version": "7.6.3",
+          "resolved": "http://artprod.dev.bloomberg.com/artifactory/api/npm/npm-repos/@babel/generator/-/generator-7.6.3.tgz",
+          "integrity": "sha1-cdU3UmT5Pse6x9nzWmcGdzP1V44=",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.6.3",
+            "jsesc": "^2.5.1",
+            "lodash": "^4.17.13",
+            "source-map": "^0.6.1"
+          },
+          "dependencies": {
+            "@babel/types": {
+              "version": "7.6.3",
+              "resolved": "http://artprod.dev.bloomberg.com/artifactory/api/npm/npm-repos/@babel/types/-/types-7.6.3.tgz",
+              "integrity": "sha1-PwfZb4VPmOL71FxksMuULRHougk=",
+              "dev": true,
+              "requires": {
+                "esutils": "^2.0.2",
+                "lodash": "^4.17.13",
+                "to-fast-properties": "^2.0.0"
+              }
+            }
+          }
+        },
+        "@babel/parser": {
+          "version": "7.6.3",
+          "resolved": "http://artprod.dev.bloomberg.com/artifactory/api/npm/npm-repos/@babel/parser/-/parser-7.6.3.tgz",
+          "integrity": "sha1-nv+LnD7q4Wp02NT/MNor0NbwSH4=",
+          "dev": true
+        },
+        "@babel/traverse": {
+          "version": "7.6.3",
+          "resolved": "http://artprod.dev.bloomberg.com/artifactory/api/npm/npm-repos/@babel/traverse/-/traverse-7.6.3.tgz",
+          "integrity": "sha1-ZtfboUawhnA8D7EN1Yi3NkzsR/k=",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.5.5",
+            "@babel/generator": "^7.6.3",
+            "@babel/helper-function-name": "^7.1.0",
+            "@babel/helper-split-export-declaration": "^7.4.4",
+            "@babel/parser": "^7.6.3",
+            "@babel/types": "^7.6.3",
+            "debug": "^4.1.0",
+            "globals": "^11.1.0",
+            "lodash": "^4.17.13"
+          },
+          "dependencies": {
+            "@babel/types": {
+              "version": "7.6.3",
+              "resolved": "http://artprod.dev.bloomberg.com/artifactory/api/npm/npm-repos/@babel/types/-/types-7.6.3.tgz",
+              "integrity": "sha1-PwfZb4VPmOL71FxksMuULRHougk=",
+              "dev": true,
+              "requires": {
+                "esutils": "^2.0.2",
+                "lodash": "^4.17.13",
+                "to-fast-properties": "^2.0.0"
+              }
+            }
+          }
+        },
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "http://artprod.dev.bloomberg.com/artifactory/api/npm/npm-repos/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "http://artprod.dev.bloomberg.com/artifactory/api/npm/npm-repos/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
+          "dev": true
+        }
       }
     },
     "@babel/highlight": {
@@ -142,6 +548,95 @@
       "integrity": "sha512-+o2q111WEx4srBs7L9eJmcwi655eD8sXniLqMB93TBK9GrNzGrxDWSjiqz2hLU0Ha8MTXFIP0yd9fNdP+m43ZQ==",
       "dev": true
     },
+    "@babel/plugin-proposal-async-generator-functions": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.2.0.tgz",
+      "integrity": "sha512-+Dfo/SCQqrwx48ptLVGLdE39YtWRuKc/Y9I5Fy0P1DDBB9lsAHpjcEJQt+4IifuSOSTLBKJObJqMvaO1pIE8LQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/helper-remap-async-to-generator": "^7.1.0",
+        "@babel/plugin-syntax-async-generators": "^7.2.0"
+      }
+    },
+    "@babel/plugin-proposal-dynamic-import": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.5.0.tgz",
+      "integrity": "sha512-x/iMjggsKTFHYC6g11PL7Qy58IK8H5zqfm9e6hu4z1iH2IRyAp9u9dL80zA6R76yFovETFLKz2VJIC2iIPBuFw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-syntax-dynamic-import": "^7.2.0"
+      }
+    },
+    "@babel/plugin-proposal-json-strings": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.2.0.tgz",
+      "integrity": "sha512-MAFV1CA/YVmYwZG0fBQyXhmj0BHCB5egZHCKWIFVv/XCxAeVGIHfos3SwDck4LvCllENIAg7xMKOG5kH0dzyUg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-syntax-json-strings": "^7.2.0"
+      }
+    },
+    "@babel/plugin-proposal-object-rest-spread": {
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.6.2.tgz",
+      "integrity": "sha512-LDBXlmADCsMZV1Y9OQwMc0MyGZ8Ta/zlD9N67BfQT8uYwkRswiu2hU6nJKrjrt/58aH/vqfQlR/9yId/7A2gWw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-syntax-object-rest-spread": "^7.2.0"
+      }
+    },
+    "@babel/plugin-proposal-optional-catch-binding": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.2.0.tgz",
+      "integrity": "sha512-mgYj3jCcxug6KUcX4OBoOJz3CMrwRfQELPQ5560F70YQUBZB7uac9fqaWamKR1iWUzGiK2t0ygzjTScZnVz75g==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-syntax-optional-catch-binding": "^7.2.0"
+      }
+    },
+    "@babel/plugin-proposal-unicode-property-regex": {
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.6.2.tgz",
+      "integrity": "sha512-NxHETdmpeSCtiatMRYWVJo7266rrvAC3DTeG5exQBIH/fMIUK7ejDNznBbn3HQl/o9peymRRg7Yqkx6PdUXmMw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/helper-regex": "^7.4.4",
+        "regexpu-core": "^4.6.0"
+      }
+    },
+    "@babel/plugin-syntax-async-generators": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.2.0.tgz",
+      "integrity": "sha512-1ZrIRBv2t0GSlcwVoQ6VgSLpLgiN/FVQUzt9znxo7v2Ov4jJrs8RY8tv0wvDmFN3qIdMKWrmMMW6yZ0G19MfGg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-syntax-dynamic-import": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.2.0.tgz",
+      "integrity": "sha512-mVxuJ0YroI/h/tbFTPGZR8cv6ai+STMKNBq0f8hFxsxWjl94qqhsb+wXbpNMDPU3cfR1TIsVFzU3nXyZMqyK4w==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-syntax-json-strings": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.2.0.tgz",
+      "integrity": "sha512-5UGYnMSLRE1dqqZwug+1LISpA403HzlSfsg6P9VXU6TBjcSHeNlw4DxDx7LgpF+iKZoOG/+uzqoRHTdcUpiZNg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
     "@babel/plugin-syntax-object-rest-spread": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.2.0.tgz",
@@ -149,6 +644,424 @@
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-syntax-optional-catch-binding": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.2.0.tgz",
+      "integrity": "sha512-bDe4xKNhb0LI7IvZHiA13kff0KEfaGX/Hv4lMA9+7TEc63hMNvfKo6ZFpXhKuEp+II/q35Gc4NoMeDZyaUbj9w==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-syntax-typescript": {
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.3.3.tgz",
+      "integrity": "sha512-dGwbSMA1YhVS8+31CnPR7LB4pcbrzcV99wQzby4uAfrkZPYZlQ7ImwdpzLqi6Z6IL02b8IAL379CaMwo0x5Lag==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-arrow-functions": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.2.0.tgz",
+      "integrity": "sha512-ER77Cax1+8/8jCB9fo4Ud161OZzWN5qawi4GusDuRLcDbDG+bIGYY20zb2dfAFdTRGzrfq2xZPvF0R64EHnimg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-async-to-generator": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.5.0.tgz",
+      "integrity": "sha512-mqvkzwIGkq0bEF1zLRRiTdjfomZJDV33AH3oQzHVGkI2VzEmXLpKKOBvEVaFZBJdN0XTyH38s9j/Kiqr68dggg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.0.0",
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/helper-remap-async-to-generator": "^7.1.0"
+      }
+    },
+    "@babel/plugin-transform-block-scoped-functions": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.2.0.tgz",
+      "integrity": "sha512-ntQPR6q1/NKuphly49+QiQiTN0O63uOwjdD6dhIjSWBI5xlrbUFh720TIpzBhpnrLfv2tNH/BXvLIab1+BAI0w==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-block-scoping": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.6.3.tgz",
+      "integrity": "sha512-7hvrg75dubcO3ZI2rjYTzUrEuh1E9IyDEhhB6qfcooxhDA33xx2MasuLVgdxzcP6R/lipAC6n9ub9maNW6RKdw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "lodash": "^4.17.13"
+      }
+    },
+    "@babel/plugin-transform-classes": {
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.5.5.tgz",
+      "integrity": "sha512-U2htCNK/6e9K7jGyJ++1p5XRU+LJjrwtoiVn9SzRlDT2KubcZ11OOwy3s24TjHxPgxNwonCYP7U2K51uVYCMDg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-annotate-as-pure": "^7.0.0",
+        "@babel/helper-define-map": "^7.5.5",
+        "@babel/helper-function-name": "^7.1.0",
+        "@babel/helper-optimise-call-expression": "^7.0.0",
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/helper-replace-supers": "^7.5.5",
+        "@babel/helper-split-export-declaration": "^7.4.4",
+        "globals": "^11.1.0"
+      }
+    },
+    "@babel/plugin-transform-computed-properties": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.2.0.tgz",
+      "integrity": "sha512-kP/drqTxY6Xt3NNpKiMomfgkNn4o7+vKxK2DDKcBG9sHj51vHqMBGy8wbDS/J4lMxnqs153/T3+DmCEAkC5cpA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-destructuring": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.6.0.tgz",
+      "integrity": "sha512-2bGIS5P1v4+sWTCnKNDZDxbGvEqi0ijeqM/YqHtVGrvG2y0ySgnEEhXErvE9dA0bnIzY9bIzdFK0jFA46ASIIQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-dotall-regex": {
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.6.2.tgz",
+      "integrity": "sha512-KGKT9aqKV+9YMZSkowzYoYEiHqgaDhGmPNZlZxX6UeHC4z30nC1J9IrZuGqbYFB1jaIGdv91ujpze0exiVK8bA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/helper-regex": "^7.4.4",
+        "regexpu-core": "^4.6.0"
+      }
+    },
+    "@babel/plugin-transform-duplicate-keys": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.5.0.tgz",
+      "integrity": "sha512-igcziksHizyQPlX9gfSjHkE2wmoCH3evvD2qR5w29/Dk0SMKE/eOI7f1HhBdNhR/zxJDqrgpoDTq5YSLH/XMsQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-exponentiation-operator": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.2.0.tgz",
+      "integrity": "sha512-umh4hR6N7mu4Elq9GG8TOu9M0bakvlsREEC+ialrQN6ABS4oDQ69qJv1VtR3uxlKMCQMCvzk7vr17RHKcjx68A==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-builder-binary-assignment-operator-visitor": "^7.1.0",
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-for-of": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.4.4.tgz",
+      "integrity": "sha512-9T/5Dlr14Z9TIEXLXkt8T1DU7F24cbhwhMNUziN3hB1AXoZcdzPcTiKGRn/6iOymDqtTKWnr/BtRKN9JwbKtdQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-function-name": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.4.4.tgz",
+      "integrity": "sha512-iU9pv7U+2jC9ANQkKeNF6DrPy4GBa4NWQtl6dHB4Pb3izX2JOEvDTFarlNsBj/63ZEzNNIAMs3Qw4fNCcSOXJA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-function-name": "^7.1.0",
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-literals": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.2.0.tgz",
+      "integrity": "sha512-2ThDhm4lI4oV7fVQ6pNNK+sx+c/GM5/SaML0w/r4ZB7sAneD/piDJtwdKlNckXeyGK7wlwg2E2w33C/Hh+VFCg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-member-expression-literals": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.2.0.tgz",
+      "integrity": "sha512-HiU3zKkSU6scTidmnFJ0bMX8hz5ixC93b4MHMiYebmk2lUVNGOboPsqQvx5LzooihijUoLR/v7Nc1rbBtnc7FA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-modules-amd": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.5.0.tgz",
+      "integrity": "sha512-n20UsQMKnWrltocZZm24cRURxQnWIvsABPJlw/fvoy9c6AgHZzoelAIzajDHAQrDpuKFFPPcFGd7ChsYuIUMpg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-transforms": "^7.1.0",
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "babel-plugin-dynamic-import-node": "^2.3.0"
+      }
+    },
+    "@babel/plugin-transform-modules-commonjs": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.6.0.tgz",
+      "integrity": "sha512-Ma93Ix95PNSEngqomy5LSBMAQvYKVe3dy+JlVJSHEXZR5ASL9lQBedMiCyVtmTLraIDVRE3ZjTZvmXXD2Ozw3g==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-transforms": "^7.4.4",
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/helper-simple-access": "^7.1.0",
+        "babel-plugin-dynamic-import-node": "^2.3.0"
+      }
+    },
+    "@babel/plugin-transform-modules-systemjs": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.5.0.tgz",
+      "integrity": "sha512-Q2m56tyoQWmuNGxEtUyeEkm6qJYFqs4c+XyXH5RAuYxObRNz9Zgj/1g2GMnjYp2EUyEy7YTrxliGCXzecl/vJg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-hoist-variables": "^7.4.4",
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "babel-plugin-dynamic-import-node": "^2.3.0"
+      }
+    },
+    "@babel/plugin-transform-modules-umd": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.2.0.tgz",
+      "integrity": "sha512-BV3bw6MyUH1iIsGhXlOK6sXhmSarZjtJ/vMiD9dNmpY8QXFFQTj+6v92pcfy1iqa8DeAfJFwoxcrS/TUZda6sw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-transforms": "^7.1.0",
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-named-capturing-groups-regex": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.6.3.tgz",
+      "integrity": "sha512-jTkk7/uE6H2s5w6VlMHeWuH+Pcy2lmdwFoeWCVnvIrDUnB5gQqTVI8WfmEAhF2CDEarGrknZcmSFg1+bkfCoSw==",
+      "dev": true,
+      "requires": {
+        "regexpu-core": "^4.6.0"
+      }
+    },
+    "@babel/plugin-transform-new-target": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.4.4.tgz",
+      "integrity": "sha512-r1z3T2DNGQwwe2vPGZMBNjioT2scgWzK9BCnDEh+46z8EEwXBq24uRzd65I7pjtugzPSj921aM15RpESgzsSuA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-object-super": {
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.5.5.tgz",
+      "integrity": "sha512-un1zJQAhSosGFBduPgN/YFNvWVpRuHKU7IHBglLoLZsGmruJPOo6pbInneflUdmq7YvSVqhpPs5zdBvLnteltQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/helper-replace-supers": "^7.5.5"
+      }
+    },
+    "@babel/plugin-transform-parameters": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.4.4.tgz",
+      "integrity": "sha512-oMh5DUO1V63nZcu/ZVLQFqiihBGo4OpxJxR1otF50GMeCLiRx5nUdtokd+u9SuVJrvvuIh9OosRFPP4pIPnwmw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-call-delegate": "^7.4.4",
+        "@babel/helper-get-function-arity": "^7.0.0",
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-property-literals": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.2.0.tgz",
+      "integrity": "sha512-9q7Dbk4RhgcLp8ebduOpCbtjh7C0itoLYHXd9ueASKAG/is5PQtMR5VJGka9NKqGhYEGn5ITahd4h9QeBMylWQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-regenerator": {
+      "version": "7.4.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.4.5.tgz",
+      "integrity": "sha512-gBKRh5qAaCWntnd09S8QC7r3auLCqq5DI6O0DlfoyDjslSBVqBibrMdsqO+Uhmx3+BlOmE/Kw1HFxmGbv0N9dA==",
+      "dev": true,
+      "requires": {
+        "regenerator-transform": "^0.14.0"
+      }
+    },
+    "@babel/plugin-transform-reserved-words": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.2.0.tgz",
+      "integrity": "sha512-fz43fqW8E1tAB3DKF19/vxbpib1fuyCwSPE418ge5ZxILnBhWyhtPgz8eh1RCGGJlwvksHkyxMxh0eenFi+kFw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-shorthand-properties": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.2.0.tgz",
+      "integrity": "sha512-QP4eUM83ha9zmYtpbnyjTLAGKQritA5XW/iG9cjtuOI8s1RuL/3V6a3DeSHfKutJQ+ayUfeZJPcnCYEQzaPQqg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-spread": {
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.6.2.tgz",
+      "integrity": "sha512-DpSvPFryKdK1x+EDJYCy28nmAaIMdxmhot62jAXF/o99iA33Zj2Lmcp3vDmz+MUh0LNYVPvfj5iC3feb3/+PFg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-sticky-regex": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.2.0.tgz",
+      "integrity": "sha512-KKYCoGaRAf+ckH8gEL3JHUaFVyNHKe3ASNsZ+AlktgHevvxGigoIttrEJb8iKN03Q7Eazlv1s6cx2B2cQ3Jabw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/helper-regex": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-template-literals": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.4.4.tgz",
+      "integrity": "sha512-mQrEC4TWkhLN0z8ygIvEL9ZEToPhG5K7KDW3pzGqOfIGZ28Jb0POUkeWcoz8HnHvhFy6dwAT1j8OzqN8s804+g==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-annotate-as-pure": "^7.0.0",
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-typeof-symbol": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.2.0.tgz",
+      "integrity": "sha512-2LNhETWYxiYysBtrBTqL8+La0jIoQQnIScUJc74OYvUGRmkskNY4EzLCnjHBzdmb38wqtTaixpo1NctEcvMDZw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-typescript": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.6.3.tgz",
+      "integrity": "sha512-aiWINBrPMSC3xTXRNM/dfmyYuPNKY/aexYqBgh0HBI5Y+WO5oRAqW/oROYeYHrF4Zw12r9rK4fMk/ZlAmqx/FQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-create-class-features-plugin": "^7.6.0",
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-syntax-typescript": "^7.2.0"
+      }
+    },
+    "@babel/plugin-transform-unicode-regex": {
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.6.2.tgz",
+      "integrity": "sha512-orZI6cWlR3nk2YmYdb0gImrgCUwb5cBUwjf6Ks6dvNVvXERkwtJWOQaEOjPiu0Gu1Tq6Yq/hruCZZOOi9F34Dw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/helper-regex": "^7.4.4",
+        "regexpu-core": "^4.6.0"
+      }
+    },
+    "@babel/preset-env": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.6.3.tgz",
+      "integrity": "sha512-CWQkn7EVnwzlOdR5NOm2+pfgSNEZmvGjOhlCHBDq0J8/EStr+G+FvPEiz9B56dR6MoiUFjXhfE4hjLoAKKJtIQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.0.0",
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-proposal-async-generator-functions": "^7.2.0",
+        "@babel/plugin-proposal-dynamic-import": "^7.5.0",
+        "@babel/plugin-proposal-json-strings": "^7.2.0",
+        "@babel/plugin-proposal-object-rest-spread": "^7.6.2",
+        "@babel/plugin-proposal-optional-catch-binding": "^7.2.0",
+        "@babel/plugin-proposal-unicode-property-regex": "^7.6.2",
+        "@babel/plugin-syntax-async-generators": "^7.2.0",
+        "@babel/plugin-syntax-dynamic-import": "^7.2.0",
+        "@babel/plugin-syntax-json-strings": "^7.2.0",
+        "@babel/plugin-syntax-object-rest-spread": "^7.2.0",
+        "@babel/plugin-syntax-optional-catch-binding": "^7.2.0",
+        "@babel/plugin-transform-arrow-functions": "^7.2.0",
+        "@babel/plugin-transform-async-to-generator": "^7.5.0",
+        "@babel/plugin-transform-block-scoped-functions": "^7.2.0",
+        "@babel/plugin-transform-block-scoping": "^7.6.3",
+        "@babel/plugin-transform-classes": "^7.5.5",
+        "@babel/plugin-transform-computed-properties": "^7.2.0",
+        "@babel/plugin-transform-destructuring": "^7.6.0",
+        "@babel/plugin-transform-dotall-regex": "^7.6.2",
+        "@babel/plugin-transform-duplicate-keys": "^7.5.0",
+        "@babel/plugin-transform-exponentiation-operator": "^7.2.0",
+        "@babel/plugin-transform-for-of": "^7.4.4",
+        "@babel/plugin-transform-function-name": "^7.4.4",
+        "@babel/plugin-transform-literals": "^7.2.0",
+        "@babel/plugin-transform-member-expression-literals": "^7.2.0",
+        "@babel/plugin-transform-modules-amd": "^7.5.0",
+        "@babel/plugin-transform-modules-commonjs": "^7.6.0",
+        "@babel/plugin-transform-modules-systemjs": "^7.5.0",
+        "@babel/plugin-transform-modules-umd": "^7.2.0",
+        "@babel/plugin-transform-named-capturing-groups-regex": "^7.6.3",
+        "@babel/plugin-transform-new-target": "^7.4.4",
+        "@babel/plugin-transform-object-super": "^7.5.5",
+        "@babel/plugin-transform-parameters": "^7.4.4",
+        "@babel/plugin-transform-property-literals": "^7.2.0",
+        "@babel/plugin-transform-regenerator": "^7.4.5",
+        "@babel/plugin-transform-reserved-words": "^7.2.0",
+        "@babel/plugin-transform-shorthand-properties": "^7.2.0",
+        "@babel/plugin-transform-spread": "^7.6.2",
+        "@babel/plugin-transform-sticky-regex": "^7.2.0",
+        "@babel/plugin-transform-template-literals": "^7.4.4",
+        "@babel/plugin-transform-typeof-symbol": "^7.2.0",
+        "@babel/plugin-transform-unicode-regex": "^7.6.2",
+        "@babel/types": "^7.6.3",
+        "browserslist": "^4.6.0",
+        "core-js-compat": "^3.1.1",
+        "invariant": "^2.2.2",
+        "js-levenshtein": "^1.1.3",
+        "semver": "^5.5.0"
+      },
+      "dependencies": {
+        "@babel/types": {
+          "version": "7.6.3",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.6.3.tgz",
+          "integrity": "sha512-CqbcpTxMcpuQTMhjI37ZHVgjBkysg5icREQIEZ0eG1yCNwg3oy+5AaLiOKmjsCj6nqOsa6Hf0ObjRVwokb7srA==",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.13",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
+      }
+    },
+    "@babel/preset-typescript": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.6.0.tgz",
+      "integrity": "sha512-4xKw3tTcCm0qApyT6PqM9qniseCE79xGHiUnNdKGdxNsGUc2X7WwZybqIpnTmoukg3nhPceI5KPNzNqLNeIJww==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-transform-typescript": "^7.6.0"
       }
     },
     "@babel/runtime": {
@@ -677,6 +1590,188 @@
         "lodash": "^4.17.4"
       }
     },
+    "@jupyter-widgets/controls": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@jupyter-widgets/controls/-/controls-1.5.2.tgz",
+      "integrity": "sha512-kZd1M6F16IMa0/bk1DYAvCU1AcPsv676FWQvHkMCxI8B/mrum7oCsc2iTbebaDwF6oNJbj2qAECmdUGRervavQ==",
+      "dev": true,
+      "requires": {
+        "@jupyter-widgets/base": "^1.0.0 || ^2.0.0",
+        "@phosphor/algorithm": "^1.1.0",
+        "@phosphor/domutils": "^1.1.0",
+        "@phosphor/messaging": "^1.2.1",
+        "@phosphor/signaling": "^1.2.0",
+        "@phosphor/widgets": "^1.3.0",
+        "d3-format": "^1.3.0",
+        "jquery": "^3.1.1",
+        "jquery-ui": "^1.12.1",
+        "underscore": "^1.8.3"
+      }
+    },
+    "@jupyter-widgets/jupyterlab-manager": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@jupyter-widgets/jupyterlab-manager/-/jupyterlab-manager-1.0.2.tgz",
+      "integrity": "sha512-7c5jADfFFc16gCTrZQ4X9yAQPJLcmZRipUoYEZ7+dILeJI0aJ89PCUOcBzBtPst3AxmqrLhkV728vBtwbByyIw==",
+      "dev": true,
+      "requires": {
+        "@jupyter-widgets/base": "^2.0.1",
+        "@jupyter-widgets/controls": "^1.5.2",
+        "@jupyter-widgets/output": "^2.0.0",
+        "@jupyterlab/application": "^1.0.0",
+        "@jupyterlab/coreutils": "^3.0.0",
+        "@jupyterlab/docregistry": "^1.0.0",
+        "@jupyterlab/mainmenu": "^1.0.0",
+        "@jupyterlab/notebook": "^1.0.0",
+        "@jupyterlab/outputarea": "^1.0.0",
+        "@jupyterlab/rendermime": "^1.0.0",
+        "@jupyterlab/rendermime-interfaces": "^1.3.0",
+        "@jupyterlab/services": "^4.0.0",
+        "@phosphor/algorithm": "^1.1.0",
+        "@phosphor/coreutils": "^1.3.0",
+        "@phosphor/disposable": "^1.1.1",
+        "@phosphor/messaging": "^1.2.1",
+        "@phosphor/properties": "^1.1.0",
+        "@phosphor/signaling": "^1.2.0",
+        "@phosphor/widgets": "^1.3.0",
+        "@types/backbone": "^1.4.1",
+        "jquery": "^3.1.1",
+        "semver": "^6.1.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
+      }
+    },
+    "@jupyter-widgets/output": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@jupyter-widgets/output/-/output-2.0.0.tgz",
+      "integrity": "sha512-R6e23UjX6FcoVPvgtaNRPV4Zb8/PtT8j68fRtF2Qa7jZxtHcAdS/Pq8qwUYXirwgreHFJ8aT7X/mGe4j+AiJlQ==",
+      "dev": true,
+      "requires": {
+        "@jupyter-widgets/base": "^2.0.1"
+      }
+    },
+    "@jupyterlab/application": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/application/-/application-1.1.3.tgz",
+      "integrity": "sha512-iGVIX4LrMApEAZrVhxVSS/o3iEn1QBiiXEdpQ7X8NX9aieWf2xGzvwIrNp1GxX6b3kLzkN4SMFLDAaoZDluMbg==",
+      "dev": true,
+      "requires": {
+        "@jupyterlab/apputils": "^1.1.3",
+        "@jupyterlab/coreutils": "^3.1.0",
+        "@jupyterlab/docregistry": "^1.1.3",
+        "@jupyterlab/rendermime": "^1.1.3",
+        "@jupyterlab/rendermime-interfaces": "^1.4.0",
+        "@jupyterlab/services": "^4.1.1",
+        "@jupyterlab/ui-components": "^1.1.2",
+        "@phosphor/algorithm": "^1.1.3",
+        "@phosphor/application": "^1.6.3",
+        "@phosphor/commands": "^1.6.3",
+        "@phosphor/coreutils": "^1.3.1",
+        "@phosphor/disposable": "^1.2.0",
+        "@phosphor/messaging": "^1.2.3",
+        "@phosphor/properties": "^1.1.3",
+        "@phosphor/signaling": "^1.2.3",
+        "@phosphor/widgets": "^1.8.0",
+        "font-awesome": "~4.7.0"
+      },
+      "dependencies": {
+        "@jupyterlab/apputils": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/@jupyterlab/apputils/-/apputils-1.1.3.tgz",
+          "integrity": "sha512-5kTmNSNedP+Fyhx25gk/yRiMWoEQoqP8u2qnFJslMke+5NJPRTVwi0VW45VZZ9QtnepuT44DJ41Uk7HrQ0TKCA==",
+          "dev": true,
+          "requires": {
+            "@jupyterlab/coreutils": "^3.1.0",
+            "@jupyterlab/services": "^4.1.1",
+            "@jupyterlab/ui-components": "^1.1.2",
+            "@phosphor/algorithm": "^1.1.3",
+            "@phosphor/commands": "^1.6.3",
+            "@phosphor/coreutils": "^1.3.1",
+            "@phosphor/disposable": "^1.2.0",
+            "@phosphor/domutils": "^1.1.3",
+            "@phosphor/messaging": "^1.2.3",
+            "@phosphor/properties": "^1.1.3",
+            "@phosphor/signaling": "^1.2.3",
+            "@phosphor/virtualdom": "^1.1.3",
+            "@phosphor/widgets": "^1.8.0",
+            "@types/react": "~16.8.18",
+            "react": "~16.8.4",
+            "react-dom": "~16.8.4",
+            "sanitize-html": "~1.20.1"
+          }
+        },
+        "@jupyterlab/coreutils": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/@jupyterlab/coreutils/-/coreutils-3.1.0.tgz",
+          "integrity": "sha512-ZqgzDUyanyvc86gtCrIbc1M6iniKHYmWNWHvWOcnq3KIP3wk3grchsTYPTfQDxcUS6F04baPGp/KohEU2ml40Q==",
+          "dev": true,
+          "requires": {
+            "@phosphor/commands": "^1.6.3",
+            "@phosphor/coreutils": "^1.3.1",
+            "@phosphor/disposable": "^1.2.0",
+            "@phosphor/properties": "^1.1.3",
+            "@phosphor/signaling": "^1.2.3",
+            "ajv": "^6.5.5",
+            "json5": "^2.1.0",
+            "minimist": "~1.2.0",
+            "moment": "^2.24.0",
+            "path-posix": "~1.0.0",
+            "url-parse": "~1.4.3"
+          }
+        },
+        "@jupyterlab/observables": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@jupyterlab/observables/-/observables-2.3.0.tgz",
+          "integrity": "sha512-I3Cmu0qUU3Emzai0MRBmiSHd1c42DtOuDYAru0/cvlI8xQKzin7t/EF9TahxSEBEDDNU4RRjADUYG9T3WefYtA==",
+          "dev": true,
+          "requires": {
+            "@phosphor/algorithm": "^1.1.3",
+            "@phosphor/coreutils": "^1.3.1",
+            "@phosphor/disposable": "^1.2.0",
+            "@phosphor/messaging": "^1.2.3",
+            "@phosphor/signaling": "^1.2.3"
+          }
+        },
+        "@jupyterlab/services": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/@jupyterlab/services/-/services-4.1.1.tgz",
+          "integrity": "sha512-HuayhkG+g5T4sZ1cKEJmF9KkCLnOMpcx+e5bk2cmTc3i3ByF5lp9EZOdkqG7OBc0pQz/6EaPcuiEGSHsV2706Q==",
+          "dev": true,
+          "requires": {
+            "@jupyterlab/coreutils": "^3.1.0",
+            "@jupyterlab/observables": "^2.3.0",
+            "@phosphor/algorithm": "^1.1.3",
+            "@phosphor/coreutils": "^1.3.1",
+            "@phosphor/disposable": "^1.2.0",
+            "@phosphor/signaling": "^1.2.3",
+            "node-fetch": "^2.6.0",
+            "ws": "^7.0.0"
+          }
+        },
+        "@jupyterlab/ui-components": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/@jupyterlab/ui-components/-/ui-components-1.1.2.tgz",
+          "integrity": "sha512-FdBe5Dkbt4YduaB34Cc9gHiLCzfqfs0V+SoDbyA3bKVjp12wtg27dG2nhlGOSKhZL3VcnXbfPb7w27JZ/1b4Ig==",
+          "dev": true,
+          "requires": {
+            "@blueprintjs/core": "^3.9.0",
+            "@blueprintjs/select": "^3.3.0",
+            "@jupyterlab/coreutils": "^3.1.0",
+            "@phosphor/coreutils": "^1.3.1",
+            "@phosphor/messaging": "^1.2.3",
+            "@phosphor/virtualdom": "^1.1.3",
+            "@phosphor/widgets": "^1.8.0",
+            "react": "~16.8.4",
+            "typestyle": "^2.0.1"
+          }
+        }
+      }
+    },
     "@jupyterlab/apputils": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@jupyterlab/apputils/-/apputils-1.1.0.tgz",
@@ -748,6 +1843,333 @@
         }
       }
     },
+    "@jupyterlab/attachments": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/attachments/-/attachments-1.1.3.tgz",
+      "integrity": "sha512-tx7ShV9uVeWmzqt8AN5lzCSavXN/cJN17MF3IM5PYQZmuKI6rnmvnDoyfYyXCdDIlBfSS0ioU8hqz/28grdjPQ==",
+      "dev": true,
+      "requires": {
+        "@jupyterlab/coreutils": "^3.1.0",
+        "@jupyterlab/observables": "^2.3.0",
+        "@jupyterlab/rendermime": "^1.1.3",
+        "@jupyterlab/rendermime-interfaces": "^1.4.0",
+        "@phosphor/disposable": "^1.2.0",
+        "@phosphor/signaling": "^1.2.3"
+      },
+      "dependencies": {
+        "@jupyterlab/coreutils": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/@jupyterlab/coreutils/-/coreutils-3.1.0.tgz",
+          "integrity": "sha512-ZqgzDUyanyvc86gtCrIbc1M6iniKHYmWNWHvWOcnq3KIP3wk3grchsTYPTfQDxcUS6F04baPGp/KohEU2ml40Q==",
+          "dev": true,
+          "requires": {
+            "@phosphor/commands": "^1.6.3",
+            "@phosphor/coreutils": "^1.3.1",
+            "@phosphor/disposable": "^1.2.0",
+            "@phosphor/properties": "^1.1.3",
+            "@phosphor/signaling": "^1.2.3",
+            "ajv": "^6.5.5",
+            "json5": "^2.1.0",
+            "minimist": "~1.2.0",
+            "moment": "^2.24.0",
+            "path-posix": "~1.0.0",
+            "url-parse": "~1.4.3"
+          }
+        },
+        "@jupyterlab/observables": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@jupyterlab/observables/-/observables-2.3.0.tgz",
+          "integrity": "sha512-I3Cmu0qUU3Emzai0MRBmiSHd1c42DtOuDYAru0/cvlI8xQKzin7t/EF9TahxSEBEDDNU4RRjADUYG9T3WefYtA==",
+          "dev": true,
+          "requires": {
+            "@phosphor/algorithm": "^1.1.3",
+            "@phosphor/coreutils": "^1.3.1",
+            "@phosphor/disposable": "^1.2.0",
+            "@phosphor/messaging": "^1.2.3",
+            "@phosphor/signaling": "^1.2.3"
+          }
+        }
+      }
+    },
+    "@jupyterlab/cells": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/cells/-/cells-1.1.3.tgz",
+      "integrity": "sha512-SO8vgOyEkzjBmSQMXY0IiDR/1Vfe78xMkl5jyvUglx9YvWHUXfkxCe0J7RmFpmPHtA2w1kJduRUP61NKeM4hQw==",
+      "dev": true,
+      "requires": {
+        "@jupyterlab/apputils": "^1.1.3",
+        "@jupyterlab/attachments": "^1.1.3",
+        "@jupyterlab/codeeditor": "^1.1.0",
+        "@jupyterlab/codemirror": "^1.1.3",
+        "@jupyterlab/coreutils": "^3.1.0",
+        "@jupyterlab/observables": "^2.3.0",
+        "@jupyterlab/outputarea": "^1.1.3",
+        "@jupyterlab/rendermime": "^1.1.3",
+        "@jupyterlab/services": "^4.1.1",
+        "@phosphor/algorithm": "^1.1.3",
+        "@phosphor/coreutils": "^1.3.1",
+        "@phosphor/messaging": "^1.2.3",
+        "@phosphor/signaling": "^1.2.3",
+        "@phosphor/virtualdom": "^1.1.3",
+        "@phosphor/widgets": "^1.8.0",
+        "react": "~16.8.4"
+      },
+      "dependencies": {
+        "@jupyterlab/apputils": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/@jupyterlab/apputils/-/apputils-1.1.3.tgz",
+          "integrity": "sha512-5kTmNSNedP+Fyhx25gk/yRiMWoEQoqP8u2qnFJslMke+5NJPRTVwi0VW45VZZ9QtnepuT44DJ41Uk7HrQ0TKCA==",
+          "dev": true,
+          "requires": {
+            "@jupyterlab/coreutils": "^3.1.0",
+            "@jupyterlab/services": "^4.1.1",
+            "@jupyterlab/ui-components": "^1.1.2",
+            "@phosphor/algorithm": "^1.1.3",
+            "@phosphor/commands": "^1.6.3",
+            "@phosphor/coreutils": "^1.3.1",
+            "@phosphor/disposable": "^1.2.0",
+            "@phosphor/domutils": "^1.1.3",
+            "@phosphor/messaging": "^1.2.3",
+            "@phosphor/properties": "^1.1.3",
+            "@phosphor/signaling": "^1.2.3",
+            "@phosphor/virtualdom": "^1.1.3",
+            "@phosphor/widgets": "^1.8.0",
+            "@types/react": "~16.8.18",
+            "react": "~16.8.4",
+            "react-dom": "~16.8.4",
+            "sanitize-html": "~1.20.1"
+          }
+        },
+        "@jupyterlab/coreutils": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/@jupyterlab/coreutils/-/coreutils-3.1.0.tgz",
+          "integrity": "sha512-ZqgzDUyanyvc86gtCrIbc1M6iniKHYmWNWHvWOcnq3KIP3wk3grchsTYPTfQDxcUS6F04baPGp/KohEU2ml40Q==",
+          "dev": true,
+          "requires": {
+            "@phosphor/commands": "^1.6.3",
+            "@phosphor/coreutils": "^1.3.1",
+            "@phosphor/disposable": "^1.2.0",
+            "@phosphor/properties": "^1.1.3",
+            "@phosphor/signaling": "^1.2.3",
+            "ajv": "^6.5.5",
+            "json5": "^2.1.0",
+            "minimist": "~1.2.0",
+            "moment": "^2.24.0",
+            "path-posix": "~1.0.0",
+            "url-parse": "~1.4.3"
+          }
+        },
+        "@jupyterlab/observables": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@jupyterlab/observables/-/observables-2.3.0.tgz",
+          "integrity": "sha512-I3Cmu0qUU3Emzai0MRBmiSHd1c42DtOuDYAru0/cvlI8xQKzin7t/EF9TahxSEBEDDNU4RRjADUYG9T3WefYtA==",
+          "dev": true,
+          "requires": {
+            "@phosphor/algorithm": "^1.1.3",
+            "@phosphor/coreutils": "^1.3.1",
+            "@phosphor/disposable": "^1.2.0",
+            "@phosphor/messaging": "^1.2.3",
+            "@phosphor/signaling": "^1.2.3"
+          }
+        },
+        "@jupyterlab/services": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/@jupyterlab/services/-/services-4.1.1.tgz",
+          "integrity": "sha512-HuayhkG+g5T4sZ1cKEJmF9KkCLnOMpcx+e5bk2cmTc3i3ByF5lp9EZOdkqG7OBc0pQz/6EaPcuiEGSHsV2706Q==",
+          "dev": true,
+          "requires": {
+            "@jupyterlab/coreutils": "^3.1.0",
+            "@jupyterlab/observables": "^2.3.0",
+            "@phosphor/algorithm": "^1.1.3",
+            "@phosphor/coreutils": "^1.3.1",
+            "@phosphor/disposable": "^1.2.0",
+            "@phosphor/signaling": "^1.2.3",
+            "node-fetch": "^2.6.0",
+            "ws": "^7.0.0"
+          }
+        },
+        "@jupyterlab/ui-components": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/@jupyterlab/ui-components/-/ui-components-1.1.2.tgz",
+          "integrity": "sha512-FdBe5Dkbt4YduaB34Cc9gHiLCzfqfs0V+SoDbyA3bKVjp12wtg27dG2nhlGOSKhZL3VcnXbfPb7w27JZ/1b4Ig==",
+          "dev": true,
+          "requires": {
+            "@blueprintjs/core": "^3.9.0",
+            "@blueprintjs/select": "^3.3.0",
+            "@jupyterlab/coreutils": "^3.1.0",
+            "@phosphor/coreutils": "^1.3.1",
+            "@phosphor/messaging": "^1.2.3",
+            "@phosphor/virtualdom": "^1.1.3",
+            "@phosphor/widgets": "^1.8.0",
+            "react": "~16.8.4",
+            "typestyle": "^2.0.1"
+          }
+        }
+      }
+    },
+    "@jupyterlab/codeeditor": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/codeeditor/-/codeeditor-1.1.0.tgz",
+      "integrity": "sha512-G22xSQajqJV0UxtaEkpRDsGAqumtkkpyjtN0yoqD/wlGentAllk1D1Sup99MBQKfZN+sBERbuUdLd0Oz5Q0e3g==",
+      "dev": true,
+      "requires": {
+        "@jupyterlab/coreutils": "^3.1.0",
+        "@jupyterlab/observables": "^2.3.0",
+        "@phosphor/coreutils": "^1.3.1",
+        "@phosphor/disposable": "^1.2.0",
+        "@phosphor/dragdrop": "^1.3.3",
+        "@phosphor/messaging": "^1.2.3",
+        "@phosphor/signaling": "^1.2.3",
+        "@phosphor/widgets": "^1.8.0"
+      },
+      "dependencies": {
+        "@jupyterlab/coreutils": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/@jupyterlab/coreutils/-/coreutils-3.1.0.tgz",
+          "integrity": "sha512-ZqgzDUyanyvc86gtCrIbc1M6iniKHYmWNWHvWOcnq3KIP3wk3grchsTYPTfQDxcUS6F04baPGp/KohEU2ml40Q==",
+          "dev": true,
+          "requires": {
+            "@phosphor/commands": "^1.6.3",
+            "@phosphor/coreutils": "^1.3.1",
+            "@phosphor/disposable": "^1.2.0",
+            "@phosphor/properties": "^1.1.3",
+            "@phosphor/signaling": "^1.2.3",
+            "ajv": "^6.5.5",
+            "json5": "^2.1.0",
+            "minimist": "~1.2.0",
+            "moment": "^2.24.0",
+            "path-posix": "~1.0.0",
+            "url-parse": "~1.4.3"
+          }
+        },
+        "@jupyterlab/observables": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@jupyterlab/observables/-/observables-2.3.0.tgz",
+          "integrity": "sha512-I3Cmu0qUU3Emzai0MRBmiSHd1c42DtOuDYAru0/cvlI8xQKzin7t/EF9TahxSEBEDDNU4RRjADUYG9T3WefYtA==",
+          "dev": true,
+          "requires": {
+            "@phosphor/algorithm": "^1.1.3",
+            "@phosphor/coreutils": "^1.3.1",
+            "@phosphor/disposable": "^1.2.0",
+            "@phosphor/messaging": "^1.2.3",
+            "@phosphor/signaling": "^1.2.3"
+          }
+        }
+      }
+    },
+    "@jupyterlab/codemirror": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/codemirror/-/codemirror-1.1.3.tgz",
+      "integrity": "sha512-fNNM9ks4z+5r4e1qTXt/odJnIEOw5cTpcdvH8ZDC9y9He3FQ3jXrpQBOYuqU9pjOh4QQplpX+npr/a5EvyCubA==",
+      "dev": true,
+      "requires": {
+        "@jupyterlab/apputils": "^1.1.3",
+        "@jupyterlab/codeeditor": "^1.1.0",
+        "@jupyterlab/coreutils": "^3.1.0",
+        "@jupyterlab/observables": "^2.3.0",
+        "@jupyterlab/statusbar": "^1.1.3",
+        "@phosphor/algorithm": "^1.1.3",
+        "@phosphor/commands": "^1.6.3",
+        "@phosphor/coreutils": "^1.3.1",
+        "@phosphor/disposable": "^1.2.0",
+        "@phosphor/signaling": "^1.2.3",
+        "@phosphor/widgets": "^1.8.0",
+        "codemirror": "~5.47.0",
+        "react": "~16.8.4"
+      },
+      "dependencies": {
+        "@jupyterlab/apputils": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/@jupyterlab/apputils/-/apputils-1.1.3.tgz",
+          "integrity": "sha512-5kTmNSNedP+Fyhx25gk/yRiMWoEQoqP8u2qnFJslMke+5NJPRTVwi0VW45VZZ9QtnepuT44DJ41Uk7HrQ0TKCA==",
+          "dev": true,
+          "requires": {
+            "@jupyterlab/coreutils": "^3.1.0",
+            "@jupyterlab/services": "^4.1.1",
+            "@jupyterlab/ui-components": "^1.1.2",
+            "@phosphor/algorithm": "^1.1.3",
+            "@phosphor/commands": "^1.6.3",
+            "@phosphor/coreutils": "^1.3.1",
+            "@phosphor/disposable": "^1.2.0",
+            "@phosphor/domutils": "^1.1.3",
+            "@phosphor/messaging": "^1.2.3",
+            "@phosphor/properties": "^1.1.3",
+            "@phosphor/signaling": "^1.2.3",
+            "@phosphor/virtualdom": "^1.1.3",
+            "@phosphor/widgets": "^1.8.0",
+            "@types/react": "~16.8.18",
+            "react": "~16.8.4",
+            "react-dom": "~16.8.4",
+            "sanitize-html": "~1.20.1"
+          }
+        },
+        "@jupyterlab/coreutils": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/@jupyterlab/coreutils/-/coreutils-3.1.0.tgz",
+          "integrity": "sha512-ZqgzDUyanyvc86gtCrIbc1M6iniKHYmWNWHvWOcnq3KIP3wk3grchsTYPTfQDxcUS6F04baPGp/KohEU2ml40Q==",
+          "dev": true,
+          "requires": {
+            "@phosphor/commands": "^1.6.3",
+            "@phosphor/coreutils": "^1.3.1",
+            "@phosphor/disposable": "^1.2.0",
+            "@phosphor/properties": "^1.1.3",
+            "@phosphor/signaling": "^1.2.3",
+            "ajv": "^6.5.5",
+            "json5": "^2.1.0",
+            "minimist": "~1.2.0",
+            "moment": "^2.24.0",
+            "path-posix": "~1.0.0",
+            "url-parse": "~1.4.3"
+          }
+        },
+        "@jupyterlab/observables": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@jupyterlab/observables/-/observables-2.3.0.tgz",
+          "integrity": "sha512-I3Cmu0qUU3Emzai0MRBmiSHd1c42DtOuDYAru0/cvlI8xQKzin7t/EF9TahxSEBEDDNU4RRjADUYG9T3WefYtA==",
+          "dev": true,
+          "requires": {
+            "@phosphor/algorithm": "^1.1.3",
+            "@phosphor/coreutils": "^1.3.1",
+            "@phosphor/disposable": "^1.2.0",
+            "@phosphor/messaging": "^1.2.3",
+            "@phosphor/signaling": "^1.2.3"
+          }
+        },
+        "@jupyterlab/services": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/@jupyterlab/services/-/services-4.1.1.tgz",
+          "integrity": "sha512-HuayhkG+g5T4sZ1cKEJmF9KkCLnOMpcx+e5bk2cmTc3i3ByF5lp9EZOdkqG7OBc0pQz/6EaPcuiEGSHsV2706Q==",
+          "dev": true,
+          "requires": {
+            "@jupyterlab/coreutils": "^3.1.0",
+            "@jupyterlab/observables": "^2.3.0",
+            "@phosphor/algorithm": "^1.1.3",
+            "@phosphor/coreutils": "^1.3.1",
+            "@phosphor/disposable": "^1.2.0",
+            "@phosphor/signaling": "^1.2.3",
+            "node-fetch": "^2.6.0",
+            "ws": "^7.0.0"
+          }
+        },
+        "@jupyterlab/ui-components": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/@jupyterlab/ui-components/-/ui-components-1.1.2.tgz",
+          "integrity": "sha512-FdBe5Dkbt4YduaB34Cc9gHiLCzfqfs0V+SoDbyA3bKVjp12wtg27dG2nhlGOSKhZL3VcnXbfPb7w27JZ/1b4Ig==",
+          "dev": true,
+          "requires": {
+            "@blueprintjs/core": "^3.9.0",
+            "@blueprintjs/select": "^3.3.0",
+            "@jupyterlab/coreutils": "^3.1.0",
+            "@phosphor/coreutils": "^1.3.1",
+            "@phosphor/messaging": "^1.2.3",
+            "@phosphor/virtualdom": "^1.1.3",
+            "@phosphor/widgets": "^1.8.0",
+            "react": "~16.8.4",
+            "typestyle": "^2.0.1"
+          }
+        }
+      }
+    },
     "@jupyterlab/coreutils": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@jupyterlab/coreutils/-/coreutils-3.0.0.tgz",
@@ -766,6 +2188,347 @@
         "url-parse": "~1.4.3"
       }
     },
+    "@jupyterlab/docregistry": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/docregistry/-/docregistry-1.1.3.tgz",
+      "integrity": "sha512-RsOydDPsgJmjL/yKz6kxt9vFqbmA3qq0DyM+0Kv5WGMOR30L18mwu8IK5I9hkL79CT69o+3UaeLhAAA7PvtEnA==",
+      "dev": true,
+      "requires": {
+        "@jupyterlab/apputils": "^1.1.3",
+        "@jupyterlab/codeeditor": "^1.1.0",
+        "@jupyterlab/codemirror": "^1.1.3",
+        "@jupyterlab/coreutils": "^3.1.0",
+        "@jupyterlab/observables": "^2.3.0",
+        "@jupyterlab/rendermime": "^1.1.3",
+        "@jupyterlab/rendermime-interfaces": "^1.4.0",
+        "@jupyterlab/services": "^4.1.1",
+        "@phosphor/algorithm": "^1.1.3",
+        "@phosphor/coreutils": "^1.3.1",
+        "@phosphor/disposable": "^1.2.0",
+        "@phosphor/messaging": "^1.2.3",
+        "@phosphor/signaling": "^1.2.3",
+        "@phosphor/widgets": "^1.8.0"
+      },
+      "dependencies": {
+        "@jupyterlab/apputils": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/@jupyterlab/apputils/-/apputils-1.1.3.tgz",
+          "integrity": "sha512-5kTmNSNedP+Fyhx25gk/yRiMWoEQoqP8u2qnFJslMke+5NJPRTVwi0VW45VZZ9QtnepuT44DJ41Uk7HrQ0TKCA==",
+          "dev": true,
+          "requires": {
+            "@jupyterlab/coreutils": "^3.1.0",
+            "@jupyterlab/services": "^4.1.1",
+            "@jupyterlab/ui-components": "^1.1.2",
+            "@phosphor/algorithm": "^1.1.3",
+            "@phosphor/commands": "^1.6.3",
+            "@phosphor/coreutils": "^1.3.1",
+            "@phosphor/disposable": "^1.2.0",
+            "@phosphor/domutils": "^1.1.3",
+            "@phosphor/messaging": "^1.2.3",
+            "@phosphor/properties": "^1.1.3",
+            "@phosphor/signaling": "^1.2.3",
+            "@phosphor/virtualdom": "^1.1.3",
+            "@phosphor/widgets": "^1.8.0",
+            "@types/react": "~16.8.18",
+            "react": "~16.8.4",
+            "react-dom": "~16.8.4",
+            "sanitize-html": "~1.20.1"
+          }
+        },
+        "@jupyterlab/coreutils": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/@jupyterlab/coreutils/-/coreutils-3.1.0.tgz",
+          "integrity": "sha512-ZqgzDUyanyvc86gtCrIbc1M6iniKHYmWNWHvWOcnq3KIP3wk3grchsTYPTfQDxcUS6F04baPGp/KohEU2ml40Q==",
+          "dev": true,
+          "requires": {
+            "@phosphor/commands": "^1.6.3",
+            "@phosphor/coreutils": "^1.3.1",
+            "@phosphor/disposable": "^1.2.0",
+            "@phosphor/properties": "^1.1.3",
+            "@phosphor/signaling": "^1.2.3",
+            "ajv": "^6.5.5",
+            "json5": "^2.1.0",
+            "minimist": "~1.2.0",
+            "moment": "^2.24.0",
+            "path-posix": "~1.0.0",
+            "url-parse": "~1.4.3"
+          }
+        },
+        "@jupyterlab/observables": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@jupyterlab/observables/-/observables-2.3.0.tgz",
+          "integrity": "sha512-I3Cmu0qUU3Emzai0MRBmiSHd1c42DtOuDYAru0/cvlI8xQKzin7t/EF9TahxSEBEDDNU4RRjADUYG9T3WefYtA==",
+          "dev": true,
+          "requires": {
+            "@phosphor/algorithm": "^1.1.3",
+            "@phosphor/coreutils": "^1.3.1",
+            "@phosphor/disposable": "^1.2.0",
+            "@phosphor/messaging": "^1.2.3",
+            "@phosphor/signaling": "^1.2.3"
+          }
+        },
+        "@jupyterlab/services": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/@jupyterlab/services/-/services-4.1.1.tgz",
+          "integrity": "sha512-HuayhkG+g5T4sZ1cKEJmF9KkCLnOMpcx+e5bk2cmTc3i3ByF5lp9EZOdkqG7OBc0pQz/6EaPcuiEGSHsV2706Q==",
+          "dev": true,
+          "requires": {
+            "@jupyterlab/coreutils": "^3.1.0",
+            "@jupyterlab/observables": "^2.3.0",
+            "@phosphor/algorithm": "^1.1.3",
+            "@phosphor/coreutils": "^1.3.1",
+            "@phosphor/disposable": "^1.2.0",
+            "@phosphor/signaling": "^1.2.3",
+            "node-fetch": "^2.6.0",
+            "ws": "^7.0.0"
+          }
+        },
+        "@jupyterlab/ui-components": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/@jupyterlab/ui-components/-/ui-components-1.1.2.tgz",
+          "integrity": "sha512-FdBe5Dkbt4YduaB34Cc9gHiLCzfqfs0V+SoDbyA3bKVjp12wtg27dG2nhlGOSKhZL3VcnXbfPb7w27JZ/1b4Ig==",
+          "dev": true,
+          "requires": {
+            "@blueprintjs/core": "^3.9.0",
+            "@blueprintjs/select": "^3.3.0",
+            "@jupyterlab/coreutils": "^3.1.0",
+            "@phosphor/coreutils": "^1.3.1",
+            "@phosphor/messaging": "^1.2.3",
+            "@phosphor/virtualdom": "^1.1.3",
+            "@phosphor/widgets": "^1.8.0",
+            "react": "~16.8.4",
+            "typestyle": "^2.0.1"
+          }
+        }
+      }
+    },
+    "@jupyterlab/mainmenu": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/mainmenu/-/mainmenu-1.1.3.tgz",
+      "integrity": "sha512-0xAvQDJBoFKUIwIm5v8TkjonAlnw2x8xSEpJEhRe33HtJfhOGsfz0u94gZGpxj1UcL965CZ83VqURD1NIvSJ8g==",
+      "dev": true,
+      "requires": {
+        "@jupyterlab/apputils": "^1.1.3",
+        "@jupyterlab/services": "^4.1.1",
+        "@phosphor/algorithm": "^1.1.3",
+        "@phosphor/commands": "^1.6.3",
+        "@phosphor/coreutils": "^1.3.1",
+        "@phosphor/disposable": "^1.2.0",
+        "@phosphor/widgets": "^1.8.0"
+      },
+      "dependencies": {
+        "@jupyterlab/apputils": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/@jupyterlab/apputils/-/apputils-1.1.3.tgz",
+          "integrity": "sha512-5kTmNSNedP+Fyhx25gk/yRiMWoEQoqP8u2qnFJslMke+5NJPRTVwi0VW45VZZ9QtnepuT44DJ41Uk7HrQ0TKCA==",
+          "dev": true,
+          "requires": {
+            "@jupyterlab/coreutils": "^3.1.0",
+            "@jupyterlab/services": "^4.1.1",
+            "@jupyterlab/ui-components": "^1.1.2",
+            "@phosphor/algorithm": "^1.1.3",
+            "@phosphor/commands": "^1.6.3",
+            "@phosphor/coreutils": "^1.3.1",
+            "@phosphor/disposable": "^1.2.0",
+            "@phosphor/domutils": "^1.1.3",
+            "@phosphor/messaging": "^1.2.3",
+            "@phosphor/properties": "^1.1.3",
+            "@phosphor/signaling": "^1.2.3",
+            "@phosphor/virtualdom": "^1.1.3",
+            "@phosphor/widgets": "^1.8.0",
+            "@types/react": "~16.8.18",
+            "react": "~16.8.4",
+            "react-dom": "~16.8.4",
+            "sanitize-html": "~1.20.1"
+          }
+        },
+        "@jupyterlab/coreutils": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/@jupyterlab/coreutils/-/coreutils-3.1.0.tgz",
+          "integrity": "sha512-ZqgzDUyanyvc86gtCrIbc1M6iniKHYmWNWHvWOcnq3KIP3wk3grchsTYPTfQDxcUS6F04baPGp/KohEU2ml40Q==",
+          "dev": true,
+          "requires": {
+            "@phosphor/commands": "^1.6.3",
+            "@phosphor/coreutils": "^1.3.1",
+            "@phosphor/disposable": "^1.2.0",
+            "@phosphor/properties": "^1.1.3",
+            "@phosphor/signaling": "^1.2.3",
+            "ajv": "^6.5.5",
+            "json5": "^2.1.0",
+            "minimist": "~1.2.0",
+            "moment": "^2.24.0",
+            "path-posix": "~1.0.0",
+            "url-parse": "~1.4.3"
+          }
+        },
+        "@jupyterlab/observables": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@jupyterlab/observables/-/observables-2.3.0.tgz",
+          "integrity": "sha512-I3Cmu0qUU3Emzai0MRBmiSHd1c42DtOuDYAru0/cvlI8xQKzin7t/EF9TahxSEBEDDNU4RRjADUYG9T3WefYtA==",
+          "dev": true,
+          "requires": {
+            "@phosphor/algorithm": "^1.1.3",
+            "@phosphor/coreutils": "^1.3.1",
+            "@phosphor/disposable": "^1.2.0",
+            "@phosphor/messaging": "^1.2.3",
+            "@phosphor/signaling": "^1.2.3"
+          }
+        },
+        "@jupyterlab/services": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/@jupyterlab/services/-/services-4.1.1.tgz",
+          "integrity": "sha512-HuayhkG+g5T4sZ1cKEJmF9KkCLnOMpcx+e5bk2cmTc3i3ByF5lp9EZOdkqG7OBc0pQz/6EaPcuiEGSHsV2706Q==",
+          "dev": true,
+          "requires": {
+            "@jupyterlab/coreutils": "^3.1.0",
+            "@jupyterlab/observables": "^2.3.0",
+            "@phosphor/algorithm": "^1.1.3",
+            "@phosphor/coreutils": "^1.3.1",
+            "@phosphor/disposable": "^1.2.0",
+            "@phosphor/signaling": "^1.2.3",
+            "node-fetch": "^2.6.0",
+            "ws": "^7.0.0"
+          }
+        },
+        "@jupyterlab/ui-components": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/@jupyterlab/ui-components/-/ui-components-1.1.2.tgz",
+          "integrity": "sha512-FdBe5Dkbt4YduaB34Cc9gHiLCzfqfs0V+SoDbyA3bKVjp12wtg27dG2nhlGOSKhZL3VcnXbfPb7w27JZ/1b4Ig==",
+          "dev": true,
+          "requires": {
+            "@blueprintjs/core": "^3.9.0",
+            "@blueprintjs/select": "^3.3.0",
+            "@jupyterlab/coreutils": "^3.1.0",
+            "@phosphor/coreutils": "^1.3.1",
+            "@phosphor/messaging": "^1.2.3",
+            "@phosphor/virtualdom": "^1.1.3",
+            "@phosphor/widgets": "^1.8.0",
+            "react": "~16.8.4",
+            "typestyle": "^2.0.1"
+          }
+        }
+      }
+    },
+    "@jupyterlab/notebook": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/notebook/-/notebook-1.1.3.tgz",
+      "integrity": "sha512-AgKMhtWnGsPu3Pa/MwLLMU2u+MQXM3NPVuKYJi0fgHr+v1Xwh15nDNICKSEN9UA0JbK60sUGQssQvDbOPuNTBg==",
+      "dev": true,
+      "requires": {
+        "@jupyterlab/apputils": "^1.1.3",
+        "@jupyterlab/cells": "^1.1.3",
+        "@jupyterlab/codeeditor": "^1.1.0",
+        "@jupyterlab/coreutils": "^3.1.0",
+        "@jupyterlab/docregistry": "^1.1.3",
+        "@jupyterlab/observables": "^2.3.0",
+        "@jupyterlab/rendermime": "^1.1.3",
+        "@jupyterlab/services": "^4.1.1",
+        "@jupyterlab/statusbar": "^1.1.3",
+        "@jupyterlab/ui-components": "^1.1.2",
+        "@phosphor/algorithm": "^1.1.3",
+        "@phosphor/coreutils": "^1.3.1",
+        "@phosphor/domutils": "^1.1.3",
+        "@phosphor/dragdrop": "^1.3.3",
+        "@phosphor/messaging": "^1.2.3",
+        "@phosphor/properties": "^1.1.3",
+        "@phosphor/signaling": "^1.2.3",
+        "@phosphor/virtualdom": "^1.1.3",
+        "@phosphor/widgets": "^1.8.0",
+        "react": "~16.8.4"
+      },
+      "dependencies": {
+        "@jupyterlab/apputils": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/@jupyterlab/apputils/-/apputils-1.1.3.tgz",
+          "integrity": "sha512-5kTmNSNedP+Fyhx25gk/yRiMWoEQoqP8u2qnFJslMke+5NJPRTVwi0VW45VZZ9QtnepuT44DJ41Uk7HrQ0TKCA==",
+          "dev": true,
+          "requires": {
+            "@jupyterlab/coreutils": "^3.1.0",
+            "@jupyterlab/services": "^4.1.1",
+            "@jupyterlab/ui-components": "^1.1.2",
+            "@phosphor/algorithm": "^1.1.3",
+            "@phosphor/commands": "^1.6.3",
+            "@phosphor/coreutils": "^1.3.1",
+            "@phosphor/disposable": "^1.2.0",
+            "@phosphor/domutils": "^1.1.3",
+            "@phosphor/messaging": "^1.2.3",
+            "@phosphor/properties": "^1.1.3",
+            "@phosphor/signaling": "^1.2.3",
+            "@phosphor/virtualdom": "^1.1.3",
+            "@phosphor/widgets": "^1.8.0",
+            "@types/react": "~16.8.18",
+            "react": "~16.8.4",
+            "react-dom": "~16.8.4",
+            "sanitize-html": "~1.20.1"
+          }
+        },
+        "@jupyterlab/coreutils": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/@jupyterlab/coreutils/-/coreutils-3.1.0.tgz",
+          "integrity": "sha512-ZqgzDUyanyvc86gtCrIbc1M6iniKHYmWNWHvWOcnq3KIP3wk3grchsTYPTfQDxcUS6F04baPGp/KohEU2ml40Q==",
+          "dev": true,
+          "requires": {
+            "@phosphor/commands": "^1.6.3",
+            "@phosphor/coreutils": "^1.3.1",
+            "@phosphor/disposable": "^1.2.0",
+            "@phosphor/properties": "^1.1.3",
+            "@phosphor/signaling": "^1.2.3",
+            "ajv": "^6.5.5",
+            "json5": "^2.1.0",
+            "minimist": "~1.2.0",
+            "moment": "^2.24.0",
+            "path-posix": "~1.0.0",
+            "url-parse": "~1.4.3"
+          }
+        },
+        "@jupyterlab/observables": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@jupyterlab/observables/-/observables-2.3.0.tgz",
+          "integrity": "sha512-I3Cmu0qUU3Emzai0MRBmiSHd1c42DtOuDYAru0/cvlI8xQKzin7t/EF9TahxSEBEDDNU4RRjADUYG9T3WefYtA==",
+          "dev": true,
+          "requires": {
+            "@phosphor/algorithm": "^1.1.3",
+            "@phosphor/coreutils": "^1.3.1",
+            "@phosphor/disposable": "^1.2.0",
+            "@phosphor/messaging": "^1.2.3",
+            "@phosphor/signaling": "^1.2.3"
+          }
+        },
+        "@jupyterlab/services": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/@jupyterlab/services/-/services-4.1.1.tgz",
+          "integrity": "sha512-HuayhkG+g5T4sZ1cKEJmF9KkCLnOMpcx+e5bk2cmTc3i3ByF5lp9EZOdkqG7OBc0pQz/6EaPcuiEGSHsV2706Q==",
+          "dev": true,
+          "requires": {
+            "@jupyterlab/coreutils": "^3.1.0",
+            "@jupyterlab/observables": "^2.3.0",
+            "@phosphor/algorithm": "^1.1.3",
+            "@phosphor/coreutils": "^1.3.1",
+            "@phosphor/disposable": "^1.2.0",
+            "@phosphor/signaling": "^1.2.3",
+            "node-fetch": "^2.6.0",
+            "ws": "^7.0.0"
+          }
+        },
+        "@jupyterlab/ui-components": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/@jupyterlab/ui-components/-/ui-components-1.1.2.tgz",
+          "integrity": "sha512-FdBe5Dkbt4YduaB34Cc9gHiLCzfqfs0V+SoDbyA3bKVjp12wtg27dG2nhlGOSKhZL3VcnXbfPb7w27JZ/1b4Ig==",
+          "dev": true,
+          "requires": {
+            "@blueprintjs/core": "^3.9.0",
+            "@blueprintjs/select": "^3.3.0",
+            "@jupyterlab/coreutils": "^3.1.0",
+            "@phosphor/coreutils": "^1.3.1",
+            "@phosphor/messaging": "^1.2.3",
+            "@phosphor/virtualdom": "^1.1.3",
+            "@phosphor/widgets": "^1.8.0",
+            "react": "~16.8.4",
+            "typestyle": "^2.0.1"
+          }
+        }
+      }
+    },
     "@jupyterlab/observables": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@jupyterlab/observables/-/observables-2.2.0.tgz",
@@ -776,6 +2539,242 @@
         "@phosphor/disposable": "^1.2.0",
         "@phosphor/messaging": "^1.2.3",
         "@phosphor/signaling": "^1.2.3"
+      }
+    },
+    "@jupyterlab/outputarea": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/outputarea/-/outputarea-1.1.3.tgz",
+      "integrity": "sha512-I9Arv4Vpa5Xwa6aXehOyLtfWrpMbT6M7RxrxVJEjI43mvWCouAJ7Q0MzuuUfs+98gWfjxRy86iuc9NRI8jJ/Rg==",
+      "dev": true,
+      "requires": {
+        "@jupyterlab/apputils": "^1.1.3",
+        "@jupyterlab/coreutils": "^3.1.0",
+        "@jupyterlab/observables": "^2.3.0",
+        "@jupyterlab/rendermime": "^1.1.3",
+        "@jupyterlab/rendermime-interfaces": "^1.4.0",
+        "@jupyterlab/services": "^4.1.1",
+        "@phosphor/algorithm": "^1.1.3",
+        "@phosphor/coreutils": "^1.3.1",
+        "@phosphor/disposable": "^1.2.0",
+        "@phosphor/messaging": "^1.2.3",
+        "@phosphor/properties": "^1.1.3",
+        "@phosphor/signaling": "^1.2.3",
+        "@phosphor/widgets": "^1.8.0"
+      },
+      "dependencies": {
+        "@jupyterlab/apputils": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/@jupyterlab/apputils/-/apputils-1.1.3.tgz",
+          "integrity": "sha512-5kTmNSNedP+Fyhx25gk/yRiMWoEQoqP8u2qnFJslMke+5NJPRTVwi0VW45VZZ9QtnepuT44DJ41Uk7HrQ0TKCA==",
+          "dev": true,
+          "requires": {
+            "@jupyterlab/coreutils": "^3.1.0",
+            "@jupyterlab/services": "^4.1.1",
+            "@jupyterlab/ui-components": "^1.1.2",
+            "@phosphor/algorithm": "^1.1.3",
+            "@phosphor/commands": "^1.6.3",
+            "@phosphor/coreutils": "^1.3.1",
+            "@phosphor/disposable": "^1.2.0",
+            "@phosphor/domutils": "^1.1.3",
+            "@phosphor/messaging": "^1.2.3",
+            "@phosphor/properties": "^1.1.3",
+            "@phosphor/signaling": "^1.2.3",
+            "@phosphor/virtualdom": "^1.1.3",
+            "@phosphor/widgets": "^1.8.0",
+            "@types/react": "~16.8.18",
+            "react": "~16.8.4",
+            "react-dom": "~16.8.4",
+            "sanitize-html": "~1.20.1"
+          }
+        },
+        "@jupyterlab/coreutils": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/@jupyterlab/coreutils/-/coreutils-3.1.0.tgz",
+          "integrity": "sha512-ZqgzDUyanyvc86gtCrIbc1M6iniKHYmWNWHvWOcnq3KIP3wk3grchsTYPTfQDxcUS6F04baPGp/KohEU2ml40Q==",
+          "dev": true,
+          "requires": {
+            "@phosphor/commands": "^1.6.3",
+            "@phosphor/coreutils": "^1.3.1",
+            "@phosphor/disposable": "^1.2.0",
+            "@phosphor/properties": "^1.1.3",
+            "@phosphor/signaling": "^1.2.3",
+            "ajv": "^6.5.5",
+            "json5": "^2.1.0",
+            "minimist": "~1.2.0",
+            "moment": "^2.24.0",
+            "path-posix": "~1.0.0",
+            "url-parse": "~1.4.3"
+          }
+        },
+        "@jupyterlab/observables": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@jupyterlab/observables/-/observables-2.3.0.tgz",
+          "integrity": "sha512-I3Cmu0qUU3Emzai0MRBmiSHd1c42DtOuDYAru0/cvlI8xQKzin7t/EF9TahxSEBEDDNU4RRjADUYG9T3WefYtA==",
+          "dev": true,
+          "requires": {
+            "@phosphor/algorithm": "^1.1.3",
+            "@phosphor/coreutils": "^1.3.1",
+            "@phosphor/disposable": "^1.2.0",
+            "@phosphor/messaging": "^1.2.3",
+            "@phosphor/signaling": "^1.2.3"
+          }
+        },
+        "@jupyterlab/services": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/@jupyterlab/services/-/services-4.1.1.tgz",
+          "integrity": "sha512-HuayhkG+g5T4sZ1cKEJmF9KkCLnOMpcx+e5bk2cmTc3i3ByF5lp9EZOdkqG7OBc0pQz/6EaPcuiEGSHsV2706Q==",
+          "dev": true,
+          "requires": {
+            "@jupyterlab/coreutils": "^3.1.0",
+            "@jupyterlab/observables": "^2.3.0",
+            "@phosphor/algorithm": "^1.1.3",
+            "@phosphor/coreutils": "^1.3.1",
+            "@phosphor/disposable": "^1.2.0",
+            "@phosphor/signaling": "^1.2.3",
+            "node-fetch": "^2.6.0",
+            "ws": "^7.0.0"
+          }
+        },
+        "@jupyterlab/ui-components": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/@jupyterlab/ui-components/-/ui-components-1.1.2.tgz",
+          "integrity": "sha512-FdBe5Dkbt4YduaB34Cc9gHiLCzfqfs0V+SoDbyA3bKVjp12wtg27dG2nhlGOSKhZL3VcnXbfPb7w27JZ/1b4Ig==",
+          "dev": true,
+          "requires": {
+            "@blueprintjs/core": "^3.9.0",
+            "@blueprintjs/select": "^3.3.0",
+            "@jupyterlab/coreutils": "^3.1.0",
+            "@phosphor/coreutils": "^1.3.1",
+            "@phosphor/messaging": "^1.2.3",
+            "@phosphor/virtualdom": "^1.1.3",
+            "@phosphor/widgets": "^1.8.0",
+            "react": "~16.8.4",
+            "typestyle": "^2.0.1"
+          }
+        }
+      }
+    },
+    "@jupyterlab/rendermime": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/rendermime/-/rendermime-1.1.3.tgz",
+      "integrity": "sha512-2erFyltzCm7aVWDIomiuV8lOZJGZcixyrFCQBbKTWB74Anqp6CwcgQub6CdvSbXUjkBAxOKSCIknzjKnEXUOhA==",
+      "dev": true,
+      "requires": {
+        "@jupyterlab/apputils": "^1.1.3",
+        "@jupyterlab/codemirror": "^1.1.3",
+        "@jupyterlab/coreutils": "^3.1.0",
+        "@jupyterlab/observables": "^2.3.0",
+        "@jupyterlab/rendermime-interfaces": "^1.4.0",
+        "@jupyterlab/services": "^4.1.1",
+        "@phosphor/algorithm": "^1.1.3",
+        "@phosphor/coreutils": "^1.3.1",
+        "@phosphor/messaging": "^1.2.3",
+        "@phosphor/signaling": "^1.2.3",
+        "@phosphor/widgets": "^1.8.0",
+        "lodash.escape": "^4.0.1",
+        "marked": "0.6.2"
+      },
+      "dependencies": {
+        "@jupyterlab/apputils": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/@jupyterlab/apputils/-/apputils-1.1.3.tgz",
+          "integrity": "sha512-5kTmNSNedP+Fyhx25gk/yRiMWoEQoqP8u2qnFJslMke+5NJPRTVwi0VW45VZZ9QtnepuT44DJ41Uk7HrQ0TKCA==",
+          "dev": true,
+          "requires": {
+            "@jupyterlab/coreutils": "^3.1.0",
+            "@jupyterlab/services": "^4.1.1",
+            "@jupyterlab/ui-components": "^1.1.2",
+            "@phosphor/algorithm": "^1.1.3",
+            "@phosphor/commands": "^1.6.3",
+            "@phosphor/coreutils": "^1.3.1",
+            "@phosphor/disposable": "^1.2.0",
+            "@phosphor/domutils": "^1.1.3",
+            "@phosphor/messaging": "^1.2.3",
+            "@phosphor/properties": "^1.1.3",
+            "@phosphor/signaling": "^1.2.3",
+            "@phosphor/virtualdom": "^1.1.3",
+            "@phosphor/widgets": "^1.8.0",
+            "@types/react": "~16.8.18",
+            "react": "~16.8.4",
+            "react-dom": "~16.8.4",
+            "sanitize-html": "~1.20.1"
+          }
+        },
+        "@jupyterlab/coreutils": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/@jupyterlab/coreutils/-/coreutils-3.1.0.tgz",
+          "integrity": "sha512-ZqgzDUyanyvc86gtCrIbc1M6iniKHYmWNWHvWOcnq3KIP3wk3grchsTYPTfQDxcUS6F04baPGp/KohEU2ml40Q==",
+          "dev": true,
+          "requires": {
+            "@phosphor/commands": "^1.6.3",
+            "@phosphor/coreutils": "^1.3.1",
+            "@phosphor/disposable": "^1.2.0",
+            "@phosphor/properties": "^1.1.3",
+            "@phosphor/signaling": "^1.2.3",
+            "ajv": "^6.5.5",
+            "json5": "^2.1.0",
+            "minimist": "~1.2.0",
+            "moment": "^2.24.0",
+            "path-posix": "~1.0.0",
+            "url-parse": "~1.4.3"
+          }
+        },
+        "@jupyterlab/observables": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@jupyterlab/observables/-/observables-2.3.0.tgz",
+          "integrity": "sha512-I3Cmu0qUU3Emzai0MRBmiSHd1c42DtOuDYAru0/cvlI8xQKzin7t/EF9TahxSEBEDDNU4RRjADUYG9T3WefYtA==",
+          "dev": true,
+          "requires": {
+            "@phosphor/algorithm": "^1.1.3",
+            "@phosphor/coreutils": "^1.3.1",
+            "@phosphor/disposable": "^1.2.0",
+            "@phosphor/messaging": "^1.2.3",
+            "@phosphor/signaling": "^1.2.3"
+          }
+        },
+        "@jupyterlab/services": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/@jupyterlab/services/-/services-4.1.1.tgz",
+          "integrity": "sha512-HuayhkG+g5T4sZ1cKEJmF9KkCLnOMpcx+e5bk2cmTc3i3ByF5lp9EZOdkqG7OBc0pQz/6EaPcuiEGSHsV2706Q==",
+          "dev": true,
+          "requires": {
+            "@jupyterlab/coreutils": "^3.1.0",
+            "@jupyterlab/observables": "^2.3.0",
+            "@phosphor/algorithm": "^1.1.3",
+            "@phosphor/coreutils": "^1.3.1",
+            "@phosphor/disposable": "^1.2.0",
+            "@phosphor/signaling": "^1.2.3",
+            "node-fetch": "^2.6.0",
+            "ws": "^7.0.0"
+          }
+        },
+        "@jupyterlab/ui-components": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/@jupyterlab/ui-components/-/ui-components-1.1.2.tgz",
+          "integrity": "sha512-FdBe5Dkbt4YduaB34Cc9gHiLCzfqfs0V+SoDbyA3bKVjp12wtg27dG2nhlGOSKhZL3VcnXbfPb7w27JZ/1b4Ig==",
+          "dev": true,
+          "requires": {
+            "@blueprintjs/core": "^3.9.0",
+            "@blueprintjs/select": "^3.3.0",
+            "@jupyterlab/coreutils": "^3.1.0",
+            "@phosphor/coreutils": "^1.3.1",
+            "@phosphor/messaging": "^1.2.3",
+            "@phosphor/virtualdom": "^1.1.3",
+            "@phosphor/widgets": "^1.8.0",
+            "react": "~16.8.4",
+            "typestyle": "^2.0.1"
+          }
+        }
+      }
+    },
+    "@jupyterlab/rendermime-interfaces": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/rendermime-interfaces/-/rendermime-interfaces-1.4.0.tgz",
+      "integrity": "sha512-6GtbudtK7Yl37ldnQUQ6hTUDzjVgemiDXokEdsSTLPOPoPwKw3gaEBfxrOz/LBITfqIfbpuBzYU8lQ4rHq0TfQ==",
+      "dev": true,
+      "requires": {
+        "@phosphor/coreutils": "^1.3.1",
+        "@phosphor/widgets": "^1.8.0"
       }
     },
     "@jupyterlab/services": {
@@ -791,6 +2790,119 @@
         "@phosphor/signaling": "^1.2.3",
         "node-fetch": "^2.6.0",
         "ws": "^7.0.0"
+      }
+    },
+    "@jupyterlab/statusbar": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/statusbar/-/statusbar-1.1.3.tgz",
+      "integrity": "sha512-bBJpFEFuTb/ARkDBFopqo5atU3JfZHqbytxqQv6YA/mzYCVQwCdLSJyc+vQniE+xWhoYIqd7q5g17lnxNioDLw==",
+      "dev": true,
+      "requires": {
+        "@jupyterlab/apputils": "^1.1.3",
+        "@jupyterlab/codeeditor": "^1.1.0",
+        "@jupyterlab/coreutils": "^3.1.0",
+        "@jupyterlab/services": "^4.1.1",
+        "@jupyterlab/ui-components": "^1.1.2",
+        "@phosphor/algorithm": "^1.1.3",
+        "@phosphor/coreutils": "^1.3.1",
+        "@phosphor/disposable": "^1.2.0",
+        "@phosphor/messaging": "^1.2.3",
+        "@phosphor/signaling": "^1.2.3",
+        "@phosphor/widgets": "^1.8.0",
+        "react": "~16.8.4",
+        "typestyle": "^2.0.1"
+      },
+      "dependencies": {
+        "@jupyterlab/apputils": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/@jupyterlab/apputils/-/apputils-1.1.3.tgz",
+          "integrity": "sha512-5kTmNSNedP+Fyhx25gk/yRiMWoEQoqP8u2qnFJslMke+5NJPRTVwi0VW45VZZ9QtnepuT44DJ41Uk7HrQ0TKCA==",
+          "dev": true,
+          "requires": {
+            "@jupyterlab/coreutils": "^3.1.0",
+            "@jupyterlab/services": "^4.1.1",
+            "@jupyterlab/ui-components": "^1.1.2",
+            "@phosphor/algorithm": "^1.1.3",
+            "@phosphor/commands": "^1.6.3",
+            "@phosphor/coreutils": "^1.3.1",
+            "@phosphor/disposable": "^1.2.0",
+            "@phosphor/domutils": "^1.1.3",
+            "@phosphor/messaging": "^1.2.3",
+            "@phosphor/properties": "^1.1.3",
+            "@phosphor/signaling": "^1.2.3",
+            "@phosphor/virtualdom": "^1.1.3",
+            "@phosphor/widgets": "^1.8.0",
+            "@types/react": "~16.8.18",
+            "react": "~16.8.4",
+            "react-dom": "~16.8.4",
+            "sanitize-html": "~1.20.1"
+          }
+        },
+        "@jupyterlab/coreutils": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/@jupyterlab/coreutils/-/coreutils-3.1.0.tgz",
+          "integrity": "sha512-ZqgzDUyanyvc86gtCrIbc1M6iniKHYmWNWHvWOcnq3KIP3wk3grchsTYPTfQDxcUS6F04baPGp/KohEU2ml40Q==",
+          "dev": true,
+          "requires": {
+            "@phosphor/commands": "^1.6.3",
+            "@phosphor/coreutils": "^1.3.1",
+            "@phosphor/disposable": "^1.2.0",
+            "@phosphor/properties": "^1.1.3",
+            "@phosphor/signaling": "^1.2.3",
+            "ajv": "^6.5.5",
+            "json5": "^2.1.0",
+            "minimist": "~1.2.0",
+            "moment": "^2.24.0",
+            "path-posix": "~1.0.0",
+            "url-parse": "~1.4.3"
+          }
+        },
+        "@jupyterlab/observables": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@jupyterlab/observables/-/observables-2.3.0.tgz",
+          "integrity": "sha512-I3Cmu0qUU3Emzai0MRBmiSHd1c42DtOuDYAru0/cvlI8xQKzin7t/EF9TahxSEBEDDNU4RRjADUYG9T3WefYtA==",
+          "dev": true,
+          "requires": {
+            "@phosphor/algorithm": "^1.1.3",
+            "@phosphor/coreutils": "^1.3.1",
+            "@phosphor/disposable": "^1.2.0",
+            "@phosphor/messaging": "^1.2.3",
+            "@phosphor/signaling": "^1.2.3"
+          }
+        },
+        "@jupyterlab/services": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/@jupyterlab/services/-/services-4.1.1.tgz",
+          "integrity": "sha512-HuayhkG+g5T4sZ1cKEJmF9KkCLnOMpcx+e5bk2cmTc3i3ByF5lp9EZOdkqG7OBc0pQz/6EaPcuiEGSHsV2706Q==",
+          "dev": true,
+          "requires": {
+            "@jupyterlab/coreutils": "^3.1.0",
+            "@jupyterlab/observables": "^2.3.0",
+            "@phosphor/algorithm": "^1.1.3",
+            "@phosphor/coreutils": "^1.3.1",
+            "@phosphor/disposable": "^1.2.0",
+            "@phosphor/signaling": "^1.2.3",
+            "node-fetch": "^2.6.0",
+            "ws": "^7.0.0"
+          }
+        },
+        "@jupyterlab/ui-components": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/@jupyterlab/ui-components/-/ui-components-1.1.2.tgz",
+          "integrity": "sha512-FdBe5Dkbt4YduaB34Cc9gHiLCzfqfs0V+SoDbyA3bKVjp12wtg27dG2nhlGOSKhZL3VcnXbfPb7w27JZ/1b4Ig==",
+          "dev": true,
+          "requires": {
+            "@blueprintjs/core": "^3.9.0",
+            "@blueprintjs/select": "^3.3.0",
+            "@jupyterlab/coreutils": "^3.1.0",
+            "@phosphor/coreutils": "^1.3.1",
+            "@phosphor/messaging": "^1.2.3",
+            "@phosphor/virtualdom": "^1.1.3",
+            "@phosphor/widgets": "^1.8.0",
+            "react": "~16.8.4",
+            "typestyle": "^2.0.1"
+          }
+        }
       }
     },
     "@jupyterlab/ui-components": {
@@ -980,8 +3092,8 @@
     },
     "@types/babel__core": {
       "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.3.tgz",
-      "integrity": "sha512-8fBo0UR2CcwWxeX7WIIgJ7lXjasFxoYgRnFHUj+hRvKkpiBJbxhdAPTCY6/ZKM0uxANFVzt4yObSLuTiTnazDA==",
+      "resolved": "http://artprod.dev.bloomberg.com/artifactory/api/npm/npm-repos/@types/babel__core/-/babel__core-7.1.3.tgz",
+      "integrity": "sha1-5EHqffY80IDfzQKrGZ5tFqc1/DA=",
       "dev": true,
       "requires": {
         "@babel/parser": "^7.1.0",
@@ -992,9 +3104,9 @@
       }
     },
     "@types/babel__generator": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.0.2.tgz",
-      "integrity": "sha512-NHcOfab3Zw4q5sEE2COkpfXjoE7o+PmqD9DQW4koUT3roNxwziUdXGnRndMat/LJNUtePwn1TlP4do3uoe3KZQ==",
+      "version": "7.6.0",
+      "resolved": "http://artprod.dev.bloomberg.com/artifactory/api/npm/npm-repos/@types/babel__generator/-/babel__generator-7.6.0.tgz",
+      "integrity": "sha1-8ewcEE0btGNVbstyQBireI0MFyo=",
       "dev": true,
       "requires": {
         "@babel/types": "^7.0.0"
@@ -1002,8 +3114,8 @@
     },
     "@types/babel__template": {
       "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.0.2.tgz",
-      "integrity": "sha512-/K6zCpeW7Imzgab2bLkLEbz0+1JlFSrUMdw7KoIIu+IUdu51GWaBZpd3y1VXGVXzynvGa4DaIaxNZHiON3GXUg==",
+      "resolved": "http://artprod.dev.bloomberg.com/artifactory/api/npm/npm-repos/@types/babel__template/-/babel__template-7.0.2.tgz",
+      "integrity": "sha1-T/Y9a1Lt2sHee5daUiPtMuzqkwc=",
       "dev": true,
       "requires": {
         "@babel/parser": "^7.1.0",
@@ -1012,8 +3124,8 @@
     },
     "@types/babel__traverse": {
       "version": "7.0.7",
-      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.0.7.tgz",
-      "integrity": "sha512-CeBpmX1J8kWLcDEnI3Cl2Eo6RfbGvzUctA+CjZUhOKDFbLfcr7fc4usEqLNWetrlJd7RhAkyYe2czXop4fICpw==",
+      "resolved": "http://artprod.dev.bloomberg.com/artifactory/api/npm/npm-repos/@types/babel__traverse/-/babel__traverse-7.0.7.tgz",
+      "integrity": "sha1-JJbp/1YZbMFCnHIDTgfqthIbbz8=",
       "dev": true,
       "requires": {
         "@babel/types": "^7.3.0"
@@ -1694,10 +3806,69 @@
       "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
       "dev": true
     },
+    "babel-code-frame": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+      "dev": true,
+      "requires": {
+        "chalk": "^1.1.3",
+        "esutils": "^2.0.2",
+        "js-tokens": "^3.0.2"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
+        "js-tokens": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+          "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
+      }
+    },
     "babel-jest": {
       "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-24.9.0.tgz",
-      "integrity": "sha512-ntuddfyiN+EhMw58PTNL1ph4C9rECiQXjI4nMMBKBaNjXvqLdkXpPRcMSr4iyBrJg/+wz9brFUD6RhOAT6r4Iw==",
+      "resolved": "http://artprod.dev.bloomberg.com/artifactory/api/npm/npm-repos/babel-jest/-/babel-jest-24.9.0.tgz",
+      "integrity": "sha1-P8Mny4RnuJ0U17xw4xUQSng8zVQ=",
       "dev": true,
       "requires": {
         "@jest/transform": "^24.9.0",
@@ -1707,6 +3878,24 @@
         "babel-preset-jest": "^24.9.0",
         "chalk": "^2.4.2",
         "slash": "^2.0.0"
+      }
+    },
+    "babel-messages": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+      "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-dynamic-import-node": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.0.tgz",
+      "integrity": "sha512-o6qFkpeQEBxcqt0XYlWzAVxNCSCZdUgcR8IRlhD/8DylxjjO4foPcvTW0GGKa/cVt3rvxZ7o5ippJ+/0nvLhlQ==",
+      "dev": true,
+      "requires": {
+        "object.assign": "^4.1.0"
       }
     },
     "babel-plugin-istanbul": {
@@ -1723,22 +3912,126 @@
     },
     "babel-plugin-jest-hoist": {
       "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-24.9.0.tgz",
-      "integrity": "sha512-2EMA2P8Vp7lG0RAzr4HXqtYwacfMErOuv1U3wrvxHX6rD1sV6xS3WXG3r8TRQ2r6w8OhvSdWt+z41hQNwNm3Xw==",
+      "resolved": "http://artprod.dev.bloomberg.com/artifactory/api/npm/npm-repos/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-24.9.0.tgz",
+      "integrity": "sha1-T4NwketAfgFEfIhDy+xUbQAC11Y=",
       "dev": true,
       "requires": {
         "@types/babel__traverse": "^7.0.6"
       }
     },
+    "babel-plugin-transform-es2015-modules-commonjs": {
+      "version": "6.26.2",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.2.tgz",
+      "integrity": "sha512-CV9ROOHEdrjcwhIaJNBGMBCodN+1cfkwtM1SbUHmvyy35KGT7fohbpOxkE2uLz1o6odKK2Ck/tz47z+VqQfi9Q==",
+      "dev": true,
+      "requires": {
+        "babel-plugin-transform-strict-mode": "^6.24.1",
+        "babel-runtime": "^6.26.0",
+        "babel-template": "^6.26.0",
+        "babel-types": "^6.26.0"
+      }
+    },
+    "babel-plugin-transform-strict-mode": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
+      "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
+      }
+    },
     "babel-preset-jest": {
       "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-24.9.0.tgz",
-      "integrity": "sha512-izTUuhE4TMfTRPF92fFwD2QfdXaZW08qvWTFCI51V8rW5x00UuPgc3ajRoWofXOuxjfcOM5zzSYsQS3H8KGCAg==",
+      "resolved": "http://artprod.dev.bloomberg.com/artifactory/api/npm/npm-repos/babel-preset-jest/-/babel-preset-jest-24.9.0.tgz",
+      "integrity": "sha1-GStSHiIX+x0fZ89z9wwzZlCtPNw=",
       "dev": true,
       "requires": {
         "@babel/plugin-syntax-object-rest-spread": "^7.0.0",
         "babel-plugin-jest-hoist": "^24.9.0"
       }
+    },
+    "babel-runtime": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+      "dev": true,
+      "requires": {
+        "core-js": "^2.4.0",
+        "regenerator-runtime": "^0.11.0"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.11.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+          "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+          "dev": true
+        }
+      }
+    },
+    "babel-template": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
+      "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.26.0",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "lodash": "^4.17.4"
+      }
+    },
+    "babel-traverse": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
+      "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
+      "dev": true,
+      "requires": {
+        "babel-code-frame": "^6.26.0",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "debug": "^2.6.8",
+        "globals": "^9.18.0",
+        "invariant": "^2.2.2",
+        "lodash": "^4.17.4"
+      },
+      "dependencies": {
+        "globals": {
+          "version": "9.18.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+          "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+          "dev": true
+        }
+      }
+    },
+    "babel-types": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+      "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.26.0",
+        "esutils": "^2.0.2",
+        "lodash": "^4.17.4",
+        "to-fast-properties": "^1.0.3"
+      },
+      "dependencies": {
+        "to-fast-properties": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+          "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
+          "dev": true
+        }
+      }
+    },
+    "babylon": {
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
+      "dev": true
     },
     "backbone": {
       "version": "1.2.3",
@@ -1989,6 +4282,17 @@
         "pako": "~1.0.5"
       }
     },
+    "browserslist": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.7.0.tgz",
+      "integrity": "sha512-9rGNDtnj+HaahxiVV38Gn8n8Lr8REKsel68v1sPFfIGEK6uSXTY3h9acgiT1dZVtOOUtifo/Dn8daDQ5dUgVsA==",
+      "dev": true,
+      "requires": {
+        "caniuse-lite": "^1.0.30000989",
+        "electron-to-chromium": "^1.3.247",
+        "node-releases": "^1.1.29"
+      }
+    },
     "bs-logger": {
       "version": "0.2.6",
       "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
@@ -2089,6 +4393,12 @@
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true
+    },
+    "caniuse-lite": {
+      "version": "1.0.30000999",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000999.tgz",
+      "integrity": "sha512-1CUyKyecPeksKwXZvYw0tEoaMCo/RwBlXmEtN5vVnabvO0KPd9RQLcaAuR9/1F+KDMv6esmOFWlsXuzDk+8rxg==",
       "dev": true
     },
     "capture-exit": {
@@ -2291,6 +4601,12 @@
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
       "dev": true
     },
+    "codemirror": {
+      "version": "5.47.0",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.47.0.tgz",
+      "integrity": "sha512-kV49Fr+NGFHFc/Imsx6g180hSlkGhuHxTSDDmDHOuyln0MQYFLixDY4+bFkBVeCEiepYfDimAF/e++9jPJk4QA==",
+      "dev": true
+    },
     "collection-visit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
@@ -2399,6 +4715,30 @@
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
       "dev": true
+    },
+    "core-js": {
+      "version": "2.6.10",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.10.tgz",
+      "integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA==",
+      "dev": true
+    },
+    "core-js-compat": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.3.2.tgz",
+      "integrity": "sha512-gfiK4QnNXhnnHVOIZst2XHdFfdMTPxtR0EGs0TdILMlGIft+087oH6/Sw2xTTIjpWXC9vEwsJA8VG3XTGcmO5g==",
+      "dev": true,
+      "requires": {
+        "browserslist": "^4.7.0",
+        "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
+      }
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -2909,6 +5249,12 @@
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
       }
+    },
+    "electron-to-chromium": {
+      "version": "1.3.282",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.282.tgz",
+      "integrity": "sha512-irSaDeCGgfMu1OA30bhqIBr+dx+pDJjRbwCpob7YWqVZbzXblybNzPGklVnWqv4EXxbkEAzQYqiNCqNTgu00lQ==",
+      "dev": true
     },
     "elliptic": {
       "version": "6.5.0",
@@ -3474,6 +5820,12 @@
         "readable-stream": "^2.3.6"
       }
     },
+    "font-awesome": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/font-awesome/-/font-awesome-4.7.0.tgz",
+      "integrity": "sha1-j6jPBBGhoxr9B7BtKQK7n8gVoTM=",
+      "dev": true
+    },
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
@@ -3536,6 +5888,12 @@
         "jsonfile": "^4.0.0",
         "universalify": "^0.1.0"
       }
+    },
+    "fs-readdir-recursive": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
+      "integrity": "sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA==",
+      "dev": true
     },
     "fs-write-stream-atomic": {
       "version": "1.0.10",
@@ -4272,6 +6630,23 @@
         "function-bind": "^1.1.1"
       }
     },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^2.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        }
+      }
+    },
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -4660,6 +7035,12 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true
+    },
+    "is-plain-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
       "dev": true
     },
     "is-plain-object": {
@@ -5588,6 +7969,18 @@
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.1.tgz",
       "integrity": "sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw=="
     },
+    "jquery-ui": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/jquery-ui/-/jquery-ui-1.12.1.tgz",
+      "integrity": "sha1-vLQEXI3QU5wTS8FIjN0+dop6nlE=",
+      "dev": true
+    },
+    "js-levenshtein": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
+      "integrity": "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==",
+      "dev": true
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -5816,6 +8209,12 @@
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
       "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
     },
+    "lodash.escape": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-4.0.1.tgz",
+      "integrity": "sha1-yQRGkMIeBClL6qUXcS/e0fqI3pg=",
+      "dev": true
+    },
     "lodash.escaperegexp": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
@@ -5935,6 +8334,12 @@
       "requires": {
         "object-visit": "^1.0.0"
       }
+    },
+    "marked": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.6.2.tgz",
+      "integrity": "sha512-LqxwVH3P/rqKX4EKGz7+c2G9r98WeM/SW34ybhgNGhUQNKtf1GmmSkJ6cDGJ/t6tiyae49qRkpyTw2B9HOrgUA==",
+      "dev": true
     },
     "md5.js": {
       "version": "1.3.5",
@@ -6256,6 +8661,23 @@
         "which": "^1.3.0"
       }
     },
+    "node-releases": {
+      "version": "1.1.35",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.35.tgz",
+      "integrity": "sha512-JGcM/wndCN/2elJlU0IGdVEJQQnJwsLbgPCFd2pY7V0mxf17bZ0Gb/lgOtL29ZQhvEX5shnVhxQyZz3ex94N8w==",
+      "dev": true,
+      "requires": {
+        "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
+      }
+    },
     "normalize-package-data": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
@@ -6377,6 +8799,18 @@
         "isobject": "^3.0.0"
       }
     },
+    "object.assign": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+      "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.0",
+        "object-keys": "^1.0.11"
+      }
+    },
     "object.getownpropertydescriptors": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
@@ -6448,6 +8882,17 @@
         "execa": "^1.0.0",
         "lcid": "^2.0.0",
         "mem": "^4.0.0"
+      }
+    },
+    "output-file-sync": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-2.0.1.tgz",
+      "integrity": "sha512-mDho4qm7WgIXIGf4eYU1RHN2UU5tPfVYVSRwDJw0uTmj35DQUt/eNp19N7v6T3SrR0ESTEf2up2CGO73qI35zQ==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.11",
+        "is-plain-obj": "^1.1.0",
+        "mkdirp": "^0.5.1"
       }
     },
     "p-defer": {
@@ -6771,6 +9216,12 @@
         "ansi-styles": "^3.2.0",
         "react-is": "^16.8.4"
       }
+    },
+    "private": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
+      "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
+      "dev": true
     },
     "process": {
       "version": "0.11.10",
@@ -7141,10 +9592,34 @@
         "util.promisify": "^1.0.0"
       }
     },
+    "regenerate": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
+      "integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==",
+      "dev": true
+    },
+    "regenerate-unicode-properties": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-8.1.0.tgz",
+      "integrity": "sha512-LGZzkgtLY79GeXLm8Dp0BVLdQlWICzBnJz/ipWUgo59qBaZ+BHtq51P2q1uVZlppMuUAT37SDk39qUbjTWB7bA==",
+      "dev": true,
+      "requires": {
+        "regenerate": "^1.4.0"
+      }
+    },
     "regenerator-runtime": {
       "version": "0.13.3",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
       "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
+    },
+    "regenerator-transform": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.14.1.tgz",
+      "integrity": "sha512-flVuee02C3FKRISbxhXl9mGzdbWUVHubl1SMaknjxkFB1/iqpJhArQUvRxOOPEc/9tAiX0BaQ28FJH10E4isSQ==",
+      "dev": true,
+      "requires": {
+        "private": "^0.1.6"
+      }
     },
     "regex-not": {
       "version": "1.0.2",
@@ -7154,6 +9629,43 @@
       "requires": {
         "extend-shallow": "^3.0.2",
         "safe-regex": "^1.1.0"
+      }
+    },
+    "regexpu-core": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.6.0.tgz",
+      "integrity": "sha512-YlVaefl8P5BnFYOITTNzDvan1ulLOiXJzCNZxduTIosN17b87h3bvG9yHMoHaRuo88H4mQ06Aodj5VtYGGGiTg==",
+      "dev": true,
+      "requires": {
+        "regenerate": "^1.4.0",
+        "regenerate-unicode-properties": "^8.1.0",
+        "regjsgen": "^0.5.0",
+        "regjsparser": "^0.6.0",
+        "unicode-match-property-ecmascript": "^1.0.4",
+        "unicode-match-property-value-ecmascript": "^1.1.0"
+      }
+    },
+    "regjsgen": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.0.tgz",
+      "integrity": "sha512-RnIrLhrXCX5ow/E5/Mh2O4e/oa1/jW0eaBKTSy3LaCj+M3Bqvm97GWDp2yUtzIs4LEn65zR2yiYGFqb2ApnzDA==",
+      "dev": true
+    },
+    "regjsparser": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.0.tgz",
+      "integrity": "sha512-RQ7YyokLiQBomUJuUG8iGVvkgOLxwyZM8k6d3q5SAXpg4r5TZJZigKFvC6PpD+qQ98bCDC5YelPeA3EucDoNeQ==",
+      "dev": true,
+      "requires": {
+        "jsesc": "~0.5.0"
+      },
+      "dependencies": {
+        "jsesc": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+          "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+          "dev": true
+        }
       }
     },
     "remove-trailing-separator": {
@@ -8447,6 +10959,34 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
       "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg=="
+    },
+    "unicode-canonical-property-names-ecmascript": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
+      "integrity": "sha512-jDrNnXWHd4oHiTZnx/ZG7gtUTVp+gCcTTKr8L0HjlwphROEW3+Him+IpvC+xcJEFegapiMZyZe02CyuOnRmbnQ==",
+      "dev": true
+    },
+    "unicode-match-property-ecmascript": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.4.tgz",
+      "integrity": "sha512-L4Qoh15vTfntsn4P1zqnHulG0LdXgjSO035fEpdtp6YxXhMT51Q6vgM5lYdG/5X3MjS+k/Y9Xw4SFCY9IkR0rg==",
+      "dev": true,
+      "requires": {
+        "unicode-canonical-property-names-ecmascript": "^1.0.4",
+        "unicode-property-aliases-ecmascript": "^1.0.4"
+      }
+    },
+    "unicode-match-property-value-ecmascript": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.1.0.tgz",
+      "integrity": "sha512-hDTHvaBk3RmFzvSl0UVrUmC3PuW9wKVnpoUDYH0JDkSIovzw+J5viQmeYHxVSBptubnr7PbH2e0fnpDRQnQl5g==",
+      "dev": true
+    },
+    "unicode-property-aliases-ecmascript": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.5.tgz",
+      "integrity": "sha512-L5RAqCfXqAwR3RriF8pM0lU0w4Ryf/GgzONwi6KnL1taJQa7x1TCxdJnILX59WIGOwR57IVxn7Nej0fz1Ny6fw==",
+      "dev": true
     },
     "union-value": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -67,11 +67,18 @@
     "vega-functions": "^5.3.0"
   },
   "devDependencies": {
+    "@babel/cli": "^7.6.3",
+    "@babel/core": "^7.6.3",
+    "@babel/preset-env": "^7.6.3",
+    "@babel/preset-typescript": "^7.6.0",
+    "@jupyter-widgets/jupyterlab-manager": "^1.0.2",
     "@phosphor/application": "^1.6.0",
     "@types/jest": "^24.0.18",
     "@types/node": "^10.11.6",
     "@types/webpack-env": "^1.13.6",
     "acorn": "^6.2.0",
+    "babel-jest": "^24.9.0",
+    "babel-plugin-transform-es2015-modules-commonjs": "^6.26.2",
     "css-loader": "^3.0.0",
     "file-loader": "^4.0.0",
     "fs-extra": "^7.0.0",

--- a/src/tests/datagrid.test.ts
+++ b/src/tests/datagrid.test.ts
@@ -1,0 +1,152 @@
+import {
+  DataGridModel, DataGridView,
+} from '../datagrid';
+
+import {
+  DataGenerator
+} from '../tests/testUtils'
+
+import {
+  ViewBasedJSONModel
+} from '../core/viewbasedjsonmodel';
+
+import {
+  Transform
+} from '../core/transform';
+
+import {
+  WidgetManager
+} from './testUtils';
+
+/**
+ * Tests that assigning new data to the `data` attribute of the widget behaves
+ * as intended.
+ */
+describe('Test trait: data', () => {
+
+  test('Data model is updated on trait update', async () => {
+    const testData = Private.createBasicTestData();
+    const grid = await Private.createGridWidget({ data: testData.set1 });
+    const oldDataModel = grid.model.data_model;
+    grid.model.set('data', testData.set2);
+    expect(grid.model.data_model.dataset).toEqual(testData.set2);
+    expect(grid.model.data_model).not.toBe(oldDataModel);
+  });
+
+  test('Selection model updated on trait update', async () => {
+    const testData = Private.createBasicTestData();
+    const grid = await Private.createGridWidget({
+      data: testData.set1, modelAttributes: { selection_mode: 'cell' }
+    });
+    const oldSelectionModel = grid.model.selectionModel;
+    grid.model.set('data', testData.set2);
+    expect(grid.model.selectionModel).not.toBe(oldSelectionModel);
+  });
+
+  test('Transforms are copied to new model', async () => {
+    const testData = Private.createBasicTestData();
+    const transform: Transform.TransformSpec = {
+      type: 'sort',
+      columnIndex: 0,
+      desc: true
+    }
+    const grid = await Private.createGridWidget({
+      data: testData.set1, modelAttributes: {
+        selection_mode: 'cell',
+        _transforms: [transform]
+      }
+    });
+    const oldTransforms = grid.model.data_model.transformMetadata(
+      transform.columnIndex
+    );
+    const oldDataModel = grid.model.data_model
+    grid.model.set('data', testData.set2);
+    expect(grid.model.data_model).not.toBe(oldDataModel);
+    expect(grid.model.data_model.transformMetadata(
+      transform.columnIndex
+    )).toEqual(
+      oldTransforms
+    )
+  });
+
+  test('HeaderRenderer updated with reference to new model', async () => {
+    const testData = Private.createBasicTestData();
+    const grid = await Private.createGridWidget({
+      data: testData.set1, modelAttributes: { selection_mode: 'cell' }
+    });
+    const oldColHead = grid.view.grid.cellRenderers.get('column-header', {});
+    const oldCornerHead = grid.view.grid.cellRenderers.get('column-header', {});
+    grid.model.set('data', testData.set2);
+    expect(
+      grid.view.grid.cellRenderers.get('corner-header', {})
+    ).not.toBe(oldCornerHead);
+    expect(
+      grid.view.grid.cellRenderers.get('column-header', {})
+    ).not.toBe(oldColHead);
+  });
+});
+
+namespace Private {
+  /**
+   * Creates a model and view instance for the front-end of the widget.
+   * 
+   * @param options - The options to create a grid widget
+   */
+  export function createGridWidget(
+    options: ICreateGridWidgetOptions): Promise<GridWidgetComponents> {
+    return new Promise(async (resolve) => {
+      const widgetManager = new WidgetManager()
+      const gridModel = new DataGridModel(
+        { ...options.modelAttributes, data: options.data },
+        { model_id: 'testModel', widget_manager: widgetManager }
+      );
+      const gridView = new DataGridView({ model: gridModel })
+      await gridView.render();
+      resolve({ model: gridModel, view: gridView })
+    })
+  }
+
+  /**
+   * An options object to create a grid widget for testing.
+   */
+  export interface ICreateGridWidgetOptions {
+    /**
+     * Attributes to be passed along to the model constructor.
+     */
+    modelAttributes?: { [key: string]: any }
+
+    /**
+     * The grid data to instantiate the model with.
+     */
+    data: ViewBasedJSONModel.IData
+  }
+
+  /**
+   * An object that contains references to a linked datagrid model and view.
+   */
+  export interface GridWidgetComponents {
+
+    /**
+     * The widget model instance.
+     */
+    model: DataGridModel
+
+    /**
+     * A widget view
+     */
+    view: DataGridView
+  }
+
+  /**
+   * Creates 2 sets of data in the JSON Table Schema format for testing.
+   */
+  export function createBasicTestData() {
+    const data1 = DataGenerator.singleCol({
+      data: [1, 2, 3], name: 'test', type: 'number'
+    });
+    const data2 = DataGenerator.singleCol({
+      data: [4, 5, 6], name: 'test2', type: 'number'
+    });
+    return { set1: data1, set2: data2 };
+  }
+}

--- a/src/tests/setupFile.js
+++ b/src/tests/setupFile.js
@@ -1,0 +1,4 @@
+// jsdom does not support HTML5 canvas, so we need to mock out this function
+HTMLCanvasElement.prototype.getContext = () => { 
+  return {}
+};

--- a/src/tests/testUtils.ts
+++ b/src/tests/testUtils.ts
@@ -88,6 +88,19 @@ export namespace DataGenerator {
   }
 }
 
-
-
+/**
+ * Mock widget manager for testing.
+ */
+export class WidgetManager {
+  create_view(model: any) {
+    return new Promise((resolve, reject) => {
+      resolve(jest.fn())
+    })
+  }
+  display_view(model: any) {
+    return new Promise((resolve, reject) => {
+      resolve(jest.fn())
+    })
+  }
+}
 


### PR DESCRIPTION
Adds necessary config and some tests for the view side of the widget. Notes:
- We can now instantiate a widget model and view in tests to test the interactions between them (ie, check that when the `data` trait is updated, the state of the actual grid in the view is updated correctly.
- This is currently using a basic mock of a `WidgetManager`, I've been working on an actual widget manager that can send mock comm messages, so we can also test any custom messaging that may happen outside of traitlets.
- Most of the config updates are related to the need to transpile `@jupyyer-widgets/base` to CommonJS so that it can be injested by Jest.