### PR TITLE
Add native pandas support

### DIFF
--- a/examples/BoolRenderer.ipynb
+++ b/examples/BoolRenderer.ipynb
@@ -29,7 +29,6 @@
     "    'Value 3': np.random.choice([True, False], n),\n",
     "    'Value 4': np.random.choice([True, False], n),\n",
     "})\n",
-    "jsontable = json.loads(df.to_json(orient='table'))\n",
     "\n",
     "# This returns the unicode value for specific font-awesome icons, \n",
     "# check-out this link for more icons: \n",
@@ -91,7 +90,7 @@
     "\n",
     "display(df)\n",
     "\n",
-    "DataGrid(data=jsontable, base_row_size=30, base_column_size=150, renderers=renderers)"
+    "DataGrid(df, base_row_size=30, base_column_size=150, renderers=renderers)"
    ]
   },
   {
@@ -118,7 +117,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.6.6"
   }
  },
  "nbformat": 4,

--- a/examples/CellEditing.ipynb
+++ b/examples/CellEditing.ipynb
@@ -24,18 +24,18 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from ipydatagrid import DataGrid\n",
     "from json import load\n",
+    "import pandas as pd\n",
     "\n",
     "with open('./cars.json') as fobj:\n",
     "    data = load(fobj)\n",
+    "df = pd.DataFrame(data['data']).drop('index', axis=1)\n",
     "\n",
-    "datagrid = DataGrid(data=data, editable=True)\n",
+    "datagrid = DataGrid(df, editable=True, layout={'height':'200px'})\n",
     "datagrid"
    ]
   },
@@ -180,13 +180,6 @@
    "source": [
     "select_all_changed_cells()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -205,9 +198,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.6.6"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/examples/DataGrid.ipynb
+++ b/examples/DataGrid.ipynb
@@ -23,9 +23,12 @@
    "outputs": [],
    "source": [
     "from json import load\n",
+    "import pandas as pd\n",
     "\n",
     "with open('./cars.json') as fobj:\n",
-    "    data = load(fobj)"
+    "    data = load(fobj)\n",
+    "df = pd.DataFrame(data['data']).set_index('index')\n",
+    "df = df[sorted(df.columns)]"
    ]
   },
   {
@@ -111,7 +114,7 @@
     "    ),\n",
     "}\n",
     "\n",
-    "datagrid = DataGrid(data=data, base_row_size=32, base_column_size=150, renderers=renderers)\n",
+    "datagrid = DataGrid(df, base_row_size=32, base_column_size=150, renderers=renderers)\n",
     "datagrid"
    ]
   },
@@ -222,7 +225,9 @@
     "    format='.3f'\n",
     ")\n",
     "\n",
-    "conditional_huge_datagrid = DataGrid(data=huge_data, default_renderer=default_renderer)\n",
+    "huge_df = pd.DataFrame(huge_data['data'])\n",
+    "\n",
+    "conditional_huge_datagrid = DataGrid(huge_df, default_renderer=default_renderer)\n",
     "conditional_huge_datagrid"
    ]
   },
@@ -254,7 +259,8 @@
     "reference_slider.observe(on_change, 'value')\n",
     "output_colorpicker.observe(on_change, 'value')\n",
     "\n",
-    "HBox((operator_dropdown, reference_slider, output_colorpicker))"
+    "hbox = HBox((operator_dropdown, reference_slider, output_colorpicker))\n",
+    "VBox([conditional_huge_datagrid, hbox])"
    ]
   },
   {
@@ -282,7 +288,9 @@
     "    show_text=False\n",
     ")\n",
     "\n",
-    "huge_datagrid = DataGrid(data=create_random_data(), default_renderer=bar_renderer)"
+    "huge_df2 = pd.DataFrame(create_random_data()['data'])\n",
+    "\n",
+    "huge_datagrid = DataGrid(huge_df2, default_renderer=bar_renderer)"
    ]
   },
   {
@@ -317,15 +325,6 @@
    "source": [
     "color_scale.scheme = 'magma'"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "huge_datagrid.data = update_random_data(huge_datagrid.data)"
-   ]
   }
  ],
  "metadata": {
@@ -344,7 +343,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.6.6"
   }
  },
  "nbformat": 4,

--- a/examples/Pandas.ipynb
+++ b/examples/Pandas.ipynb
@@ -30,7 +30,6 @@
     "    'Value 2': np.random.randn(n),\n",
     "    'Dates': pd.date_range(end=pd.Timestamp('today'), periods=n)\n",
     "})\n",
-    "jsontable = json.loads(df.to_json(orient='table'))\n",
     "\n",
     "text_renderer = TextRenderer(\n",
     "    text_color='black',\n",
@@ -52,7 +51,7 @@
     "    ),\n",
     "}\n",
     "\n",
-    "grid = DataGrid(data=jsontable, base_row_size=30, base_column_size=300, renderers=renderers)\n",
+    "grid = DataGrid(df, base_row_size=30, base_column_size=300, renderers=renderers)\n",
     "grid.transform([{'type': 'sort', 'columnIndex': 2, 'desc': True}])\n",
     "grid"
    ]
@@ -81,7 +80,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.6.6"
   }
  },
  "nbformat": 4,

--- a/examples/Selections.ipynb
+++ b/examples/Selections.ipynb
@@ -24,11 +24,14 @@
    "source": [
     "from ipydatagrid import DataGrid\n",
     "from json import load\n",
+    "import pandas as pd\n",
     "\n",
     "with open('./cars.json') as fobj:\n",
     "    data = load(fobj)\n",
     "\n",
-    "datagrid = DataGrid(data=data, selection_mode='cell')\n",
+    "df = pd.DataFrame(data['data']).drop('index', axis=1)\n",
+    "\n",
+    "datagrid = DataGrid(df, selection_mode='cell')\n",
     "datagrid"
    ]
   },
@@ -233,7 +236,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.6.6"
   }
  },
  "nbformat": 4,

--- a/examples/Trees_paris.ipynb
+++ b/examples/Trees_paris.ipynb
@@ -27,6 +27,7 @@
    "outputs": [],
    "source": [
     "from json import load\n",
+    "import pandas as pd\n",
     "\n",
     "from ipywidgets import Text, VBox\n",
     "from bqplot import LinearScale, ColorScale, OrdinalColorScale, OrdinalScale\n",
@@ -37,6 +38,9 @@
     "\n",
     "with open('./trees.json') as fobj:\n",
     "    data = load(fobj)\n",
+    "    \n",
+    "df = pd.DataFrame(data['data']).drop('index', axis=1)\n",
+    "df = df[sorted(df.columns)]\n",
     "\n",
     "# Get list of possible tree species and kinds for the ordinal color scales\n",
     "species = list(set([tree['Species'] for tree in data['data'] if tree['Species'] is not None]))\n",
@@ -82,7 +86,7 @@
     "    ),\n",
     "}\n",
     "\n",
-    "datagrid = DataGrid(data=data, base_row_size=32, base_column_size=90, renderers=renderers)\n",
+    "datagrid = DataGrid(df, base_row_size=32, base_column_size=90, renderers=renderers)\n",
     "VBox((highlight_box, datagrid))"
    ]
   },
@@ -107,7 +111,7 @@
    "source": [
     "datagrid.transform([\n",
     "    {'type': 'sort', 'columnIndex': 5},\n",
-    "    {'type': 'filter', 'operator': '=', 'columnIndex': 3, 'value': 'Platane'}\n",
+    "    {'type': 'filter', 'operator': '=', 'columnIndex': 4, 'value': 'Platane'}\n",
     "])"
    ]
   },
@@ -135,7 +139,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.6.6"
   }
  },
  "nbformat": 4,

--- a/setup.py
+++ b/setup.py
@@ -86,6 +86,7 @@ setup_args = dict(
     ],
     include_package_data = True,
     install_requires = [
+        'pandas>=0.25.0',
         'py2vega>=0.5.0',
         'ipywidgets>=7.0.0',
         'bqplot>=0.11.6'  # This is temporary, this dependency will be removed when scales are extracted from bqplot

--- a/src/datagrid.ts
+++ b/src/datagrid.ts
@@ -141,7 +141,7 @@ export
       baseRowHeaderSize: 64,
       baseColumnHeaderSize: 20,
       headerVisibility: 'all',
-      data: {},
+      _data: {},
       renderers: {},
       default_renderer: null,
       selection_mode: 'none',
@@ -153,7 +153,7 @@ export
   initialize(attributes: any, options: any) {
     super.initialize(attributes, options);
 
-    this.on('change:data', this.updateData.bind(this));
+    this.on('change:_data', this.updateData.bind(this));
     this.on('change:_transforms', this.updateTransforms.bind(this));
     this.on('change:selection_mode', this.updateSelectionModel, this);
     this.on('change:selections', this.updateSelections, this);
@@ -169,7 +169,7 @@ export
   }
 
   updateData() {
-    this.data_model = new ViewBasedJSONModel(this.get('data'));
+    this.data_model = new ViewBasedJSONModel(this.get('_data'));
     this.data_model.transformStateChanged.connect((sender, value) => {
       this.set('_transforms', value.transforms);
       this.save_changes();
@@ -181,7 +181,7 @@ export
           this.save_changes();
           break;
         case ('cell-updated'):
-          this.set('data', this.data_model.dataset);
+          this.set('_data', this.data_model.dataset);
           this.save_changes();
           break;
         default:


### PR DESCRIPTION
Updates the `DataGrid()` widget to work directly off of pandas dataframes. The `data` attribute now accepts dataframes, and converts them to JSON Table Schema format before syncing the data to the frontend with the `_data` trait.

Also updated the example notebooks to work with the interface changes.