### PR TITLE
Add bqplot link to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ the nbextension:
 jupyter nbextension enable --py [--sys-prefix|--user|--system] ipydatagrid
 ```
 
+NOTE: For examples using Scales from bqplot to work as intended, the bqplot notebook and lab extensions must be installed as well. See the [bqplot repo](https://github.com/bloomberg/bqplot) for installation instructions:
+
 ## Development installation
 
 For a development installation:


### PR DESCRIPTION
Adds a note to the `README` to inform users that the bqplot labextension also needs to be installed. In another PR, we may want to update the example notebooks to only use Scales in a specific section. The "main" example in the DataGrid notebook uses them, and the error message you get from not having the bqplot labextension isn't very helpful.