### PR TITLE
make .getDatasetRowFromView() region aware

### DIFF
--- a/src/core/viewbasedjsonmodel.ts
+++ b/src/core/viewbasedjsonmodel.ts
@@ -147,7 +147,7 @@ export class ViewBasedJSONModel extends MutableDataModel {
    *
    */
   setData(region: DataModel.CellRegion, row: number, column: number, value: any): boolean {
-    const datasetRow = this.getDatasetRowFromView(row)
+    const datasetRow = this.getDatasetRowFromView(region, row)
     this.updateCellValue({ region: region, row: datasetRow, column: column, value: value });
     this.emitChanged({ type: 'cells-changed', region: region, row: row, column: column, rowSpan: 1, columnSpan: 1 });
 
@@ -285,7 +285,11 @@ export class ViewBasedJSONModel extends MutableDataModel {
    *
    * @param options - The options for this method.
    */
-  getDatasetRowFromView(row: number): number {
+  getDatasetRowFromView(region: DataModel.CellRegion, row: number): number {
+
+    if (region == 'column-header' || region == 'corner-header') {
+      return row;
+    }
 
     // Get the index of the row in the full dataset to be updated
     const primaryKey = (Array.isArray(this._dataset.schema.primaryKey))

--- a/src/datagrid.ts
+++ b/src/datagrid.ts
@@ -137,7 +137,7 @@ class IIPyDataGridMouseHandler extends BasicMouseHandler {
           column: dataModel.metadata(hit.region, hit.row, hit.column)['name'],
           column_index: hit.column,
           row: hit.row,
-          primary_key_row: dataModel.getDatasetRowFromView(hit.row),
+          primary_key_row: dataModel.getDatasetRowFromView(hit.region, hit.row),
           cell_value: dataModel.data(hit.region, hit.row, hit.column)
         }
       }, null);
@@ -247,7 +247,7 @@ export
     this.data_model.changed.connect((sender: ViewBasedJSONModel, args: any) => {
       if (args.type === 'cells-changed') {
         const value = this.data_model.data(args.region, args.row, args.column);
-        const datasetRow = this.data_model.getDatasetRowFromView(args.row)
+        const datasetRow = this.data_model.getDatasetRowFromView(args.region, args.row)
         this.comm.send({
           method: 'custom',
           content: {


### PR DESCRIPTION
This PR adds the `region` parameter to `.getDatasetRowFromView()`. Previously, it was always assumed to `'body'`, which could result in an exception if a mouse click was on a `column-header` region while there were less `body` rows visible than `column-header` rows.