### PR TITLE
Persist column widths across data model changes

### DIFF
--- a/src/datagrid.ts
+++ b/src/datagrid.ts
@@ -508,6 +508,7 @@ export
         this.grid.dataModel = this.model.data_model;
         this.updateHeaderRenderer();
         this.filterDialog.model = this.model.data_model;
+        this.updateColumnWidths();
       });
 
       this.model.on('change:base_row_size', () => {


### PR DESCRIPTION
This PR ensures that `updateColumnWidths()` is called on data model updates, so that the columns widths will continue to represent widget state after new data is assigned.