### PR TITLE
Check for comm before sending message

### DIFF
--- a/src/datagrid.ts
+++ b/src/datagrid.ts
@@ -128,7 +128,7 @@ class IIPyDataGridMouseHandler extends BasicMouseHandler {
     this._onMouseDown = true;
 
     // Send custom message to kernel
-    if (hit.region !== 'void' && grid.dataModel) {
+    if (hit.region !== 'void' && grid.dataModel && this._dataGridView.model.comm) {
       const dataModel = <ViewBasedJSONModel>grid.dataModel;
       this._dataGridView.model.comm.send({
         method: 'custom',


### PR DESCRIPTION
This PR adds a check to validate that there is a valid comm before attempting to send a message. This resolves an issue that was preventing the grid from functioning as expected when rendered with `jupyter-sphinx` (ie, there is no live kernel)