### PR TITLE
Make CallbackDispatcher an instance attribute

### DIFF
--- a/ipydatagrid/datagrid.py
+++ b/ipydatagrid/datagrid.py
@@ -251,13 +251,11 @@ class DataGrid(DOMWidget):
     editable = Bool(False).tag(sync=True)
     column_widths = Dict({}).tag(sync=True)
 
-
-    _cell_change_handlers = CallbackDispatcher()
-    _cell_click_handlers = CallbackDispatcher()
-
     def __init__(self, dataframe, **kwargs):
         self.data = dataframe
         super(DataGrid, self).__init__(**kwargs)
+        self._cell_click_handlers = CallbackDispatcher()
+        self._cell_change_handlers = CallbackDispatcher()
         self.on_msg(self.__handle_custom_msg)
         
     def __handle_custom_msg(self, _, content, buffers):


### PR DESCRIPTION
This PR changes the callback dispatchers from class attributes to instance attributes. The side effect being caused previous to this move was that all instances of ipydatagrid ended up sharing the same callback dispatchers, so the click/change handlers were invoked for *each* grid if there was an event on *any* grid in the kernel. @mbektasbbg, since you'll need to make the same change in the FeatherGrid PR.