### PR TITLE
fix for scrollbar icons not showing in jupyter notebook

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10448,6 +10448,30 @@
         }
       }
     },
+    "url-loader": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/url-loader/-/url-loader-4.1.0.tgz",
+      "integrity": "sha512-IzgAAIC8wRrg6NYkFIJY09vtktQcsvU8V6HhtQj9PTefbYImzLB1hufqo4m+RyM5N3mLx5BqJKccgxJS+W3kqw==",
+      "dev": true,
+      "requires": {
+        "loader-utils": "^2.0.0",
+        "mime-types": "^2.1.26",
+        "schema-utils": "^2.6.5"
+      },
+      "dependencies": {
+        "loader-utils": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
+          "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
+          "dev": true,
+          "requires": {
+            "big.js": "^5.2.2",
+            "emojis-list": "^3.0.0",
+            "json5": "^2.1.2"
+          }
+        }
+      }
+    },
     "url-parse": {
       "version": "1.4.7",
       "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.7.tgz",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,8 @@
     "typescript": "~3.6.4",
     "webpack": "^4.20.2",
     "webpack-cli": "^3.1.2",
-    "svg-url-loader": "~3.0.3"
+    "svg-url-loader": "~3.0.3",
+    "url-loader": "^4.1.0"
   },
   "jupyterlab": {
     "extension": "lib/plugin"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,12 +1,25 @@
 const path = require('path');
 const version = require('./package.json').version;
 
+const luminoThemeImages = /^.*@lumino\/default-theme.*.png$/;
+
 // Custom webpack rules
 const rules = [
   { test: /\.ts$/, loader: 'ts-loader' },
   { test: /\.js$/, loader: 'source-map-loader' },
   { test: /\.css$/, use: ['style-loader', 'css-loader']},
-  { test: /\.(jpg|png|gif)$/, use: ['file-loader']},
+  {
+    test: luminoThemeImages,
+    issuer: { test: /\.css$/ },
+    use: {
+      loader: 'url-loader'
+    }
+  },
+  {
+    test: /\.(jpg|png|gif)$/,
+    exclude: luminoThemeImages,
+    use: ['file-loader']
+  },
   {
     test: /\.svg(\?v=\d+\.\d+\.\d+)?$/,
     issuer: { test: /\.css$/ },


### PR DESCRIPTION
converts pngs of `@lumino/default-theme` do data uris to fix scrollbar icon relative path issue. fixes #68 