### PR TITLE
fix falsey return statement

### DIFF
--- a/src/core/viewbasedjsonmodel.ts
+++ b/src/core/viewbasedjsonmodel.ts
@@ -237,7 +237,7 @@ export class ViewBasedJSONModel extends MutableDataModel {
 
     const indices: number[] = view.dataset.map((val, i) => {
       const lookupVal = JSON.stringify(primaryKey.map(key => val[key]));
-      const retrievedVal =this._primaryKeyMap.get(lookupVal);
+      const retrievedVal = this._primaryKeyMap.get(lookupVal);
 
       return typeof retrievedVal === "undefined" ? i : retrievedVal;
     });


### PR DESCRIPTION
Fixes an issue where calling grid.get_visible_data() after sorting has been applied on one of the columns, returns the wrong indices for visible rows.