### PR TITLE
Fix backbone view/backend sync issue when editing cells

### DIFF
--- a/src/datagrid.ts
+++ b/src/datagrid.ts
@@ -121,7 +121,6 @@ export
         const newData = this.get('_data');
         newData.data[datasetRow][args.column] = value; 
         this.set('_data', newData);
-
         // Update backend with new data
         this.comm.send({
           method: 'custom',
@@ -135,7 +134,6 @@ export
         }, null);
       }
     });
-    
     this.updateTransforms();
     this.trigger('data-model-changed');
     this.updateSelectionModel();


### PR DESCRIPTION
This PR fixes an edge case where setting data from python side, changing the data directly on the grid, and then attempting to set the original data again via python, fails. The issue was with backbone sending a custom message via lumino to the backend (backend updated correctly), but did not update the data directly on the front end, which then led to the old state persisting on the front-end, meaning that any attempts to push the old data set from python to the front end was not triggered correctly due to the two data copies being the same.