### PR TITLE
Fix cell editing when new value is excluded by transform

### DIFF
--- a/src/core/viewbasedjsonmodel.ts
+++ b/src/core/viewbasedjsonmodel.ts
@@ -633,7 +633,7 @@ namespace ViewBasedJSONModel {
     /**
      * The discriminated type of the args object.
      */
-    type: 'row-indices-updated'
+    type: 'row-indices-updated';
 
     /**
      * An list of the rows in the untransformed dataset that are currently
@@ -651,21 +651,21 @@ namespace ViewBasedJSONModel {
     /**
      * The CellRegion associated with this change.
      */
-    region: DataModel.CellRegion
+    region: DataModel.CellRegion;
 
     /**
      * The row number associated with this change.
      */
-    row: number
+    row: number;
 
     /**
      * The column index associated with this change.
      */
-    columnIndex: number
+    columnIndex: number;
 
     /**
      * The new data value
      */
-    value: ReadonlyJSONValue
+    value: ReadonlyJSONValue;
   }
 }

--- a/src/datagrid.ts
+++ b/src/datagrid.ts
@@ -109,6 +109,11 @@ export
           this.save_changes();
           break;
         case ('cell-edit-event'):
+          // Update data in widget model
+          const newData = this.get('_data');
+          newData.data[msg.row][msg.columnIndex] = msg.value; 
+          this.set('_data', newData);
+
           this.comm.send({
             method: 'custom',
             content: {
@@ -123,7 +128,8 @@ export
         default:
           throw 'unreachable';
       }
-    })
+    });
+
     this.updateTransforms();
     this.trigger('data-model-changed');
     this.updateSelectionModel();


### PR DESCRIPTION
This PR fixes an issue that would prevent the kernel-side dataset from being updated correctly after a cell event in which the new value would be immediately filtered out by a transform.