### PR TITLE
Add support for row-header formatting

### DIFF
--- a/src/feathergrid.ts
+++ b/src/feathergrid.ts
@@ -502,8 +502,6 @@ export class FeatherGrid extends Widget {
       });
     }
 
-    this.grid.cellRenderers.update({ 'row-header': this._rendererResolver.bind(this) });
-
     const scrollShadow = {
       size: 4,
       color1: Theme.getBorderColor(1, 1.0),
@@ -764,6 +762,7 @@ export class FeatherGrid extends Widget {
 
   private _updateGridRenderers() {
     this.grid.cellRenderers.update({ body: this._rendererResolver.bind(this) });
+    this.grid.cellRenderers.update({ 'row-header': this._rendererResolver.bind(this) });
   }
 
   private _updateColumnWidths() {


### PR DESCRIPTION
Users can now use the index column name when applying conditional formatting! If the index name is not passed for conditional formatting then the rowHeaderRenderer is used.

![bobisgridsuncle](https://user-images.githubusercontent.com/24281433/89945550-5ee87b80-dbd6-11ea-83b0-45a6a8e9ce1e.png)
