### PR TITLE
Fix row-header style

### DIFF
--- a/src/feathergrid.ts
+++ b/src/feathergrid.ts
@@ -502,6 +502,13 @@ export class FeatherGrid extends Widget {
       });
     }
 
+    this._rowHeaderRenderer = new TextRenderer({
+      textColor: Theme.getFontColor(1),
+      backgroundColor: Theme.getBackgroundColor(2),
+      horizontalAlignment: 'center',
+      verticalAlignment: 'center',
+    });
+
     const scrollShadow = {
       size: 4,
       color1: Theme.getBorderColor(1, 1.0),


### PR DESCRIPTION
This commit fixes the issue with the row-header is not rendering correctly when switching from light to dark theme in JupyterLab.