### PR TITLE
Add ipydatagrid-specific KeyHandler class to control keydown events 

### DIFF
--- a/js/feathergrid.ts
+++ b/js/feathergrid.ts
@@ -2,7 +2,6 @@ import { PanelLayout, Widget } from '@lumino/widgets';
 import { Message, IMessageHandler, MessageLoop } from '@lumino/messaging';
 import {
   BasicMouseHandler,
-  BasicKeyHandler,
   TextRenderer,
   DataModel,
   BasicSelectionModel,
@@ -19,6 +18,7 @@ import { FeatherGridContextMenu } from './core/gridContextMenu';
 import { ViewBasedJSONModel } from './core/viewbasedjsonmodel';
 import { Transform } from './core/transform';
 import { Theme } from './utils';
+import { KeyHandler } from './keyhandler';
 
 import '@lumino/default-theme/style/datagrid.css';
 import '../style/feathergrid.css';
@@ -489,7 +489,7 @@ export class FeatherGrid extends Widget {
 
     this.grid.dataModel = this._dataModel;
     //@ts-ignore **added so we can remove basickeyhandler.ts from fork
-    this.grid.keyHandler = new BasicKeyHandler();
+    this.grid.keyHandler = new KeyHandler();
     const mouseHandler = new FeatherGridMouseHandler(this);
     mouseHandler.cellClicked.connect(
       (sender: FeatherGridMouseHandler, hit: DataGrid.HitTestResult) => {

--- a/js/keyhandler.ts
+++ b/js/keyhandler.ts
@@ -1,0 +1,42 @@
+import { BasicKeyHandler, DataGrid } from '@lumino/datagrid';
+
+/**
+ * ipydatagrid specific KeyHandler class for handling
+ * key events. Only polymorphed events are listed here,
+ * the rest are ihnerited and used as is from the
+ * parent class.
+ */
+export class KeyHandler extends BasicKeyHandler {
+  constructor() {
+    super();
+  }
+
+  /**
+   * Handle the `'Escape'` key press for the data grid.
+   *
+   * @param grid - The data grid of interest.
+   *
+   * @param event - The keyboard event of interest.
+   */
+  protected onEscape(grid: DataGrid, event: KeyboardEvent): void {
+    // Bail if no selection model exists
+    if (!grid.selectionModel) {
+      return;
+    }
+
+    // Returns the first selection from the model, if selections exist
+    const selections = grid.selectionModel.selections().next();
+
+    if (selections) {
+      grid.selectionModel.clear();
+    } else {
+      // Chrome's implementation of focus() requires the
+      // target element to have the tabIndex attribute set.
+      // https://bugs.chromium.org/p/chromium/issues/detail?id=467043
+      if (document.body.tabIndex === -1) {
+        document.body.tabIndex = 0;
+      }
+      document.body.focus();
+    }
+  }
+}


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #203*

**Describe your changes**
Added an `ipydatagrid`-specific KeyHandler class to control the behaviour of `keydown` events. This allows us to address the issue where users cannot enter command mode on notebooks due to events being intercepted in the hierarchy above the `ipydatagrid` canvas. The new behaviour for an Escape key press event is as follows:

* If selections exist on the grid, clear those but stay focused on the grid so that the user can keep using keyboard shortcuts to control the grid, should they wish to do so.
* If no selections exist on the grid, yield focus to the `body` tag on the page. Command mode will then be available.

**Testing performed**
Tested working as expected on both JupyterLab3 and Jupyter Notebook

**Additional context**
No additional context.
