### PR TITLE
Decoupling data model from grid, and refactoring SelectionHelper

### DIFF
--- a/ipydatagrid/datagrid.py
+++ b/ipydatagrid/datagrid.py
@@ -325,7 +325,7 @@ class DataGrid(DOMWidget):
         return final_df
 
     @staticmethod
-    def generate_data_object(dataframe, guid_key):
+    def generate_data_object(dataframe, guid_key="ipydguuid"):
         dataframe[guid_key] = pd.RangeIndex(0, dataframe.shape[0])
         schema = pd.io.json.build_table_schema(dataframe)
         reset_index_dataframe = dataframe.reset_index()
@@ -534,15 +534,10 @@ class DataGrid(DOMWidget):
         # Copy of the front-end data model
         view_data = self.get_visible_data()
 
-        # New DataGrid instance with data from
-        # the front-end data model
-        selections_grid = DataGrid(view_data)
+        # Serielize to JSON table schema
+        view_data_object = DataGrid.generate_data_object(view_data, "ipydguuid")
 
-        # Copying over selections/mode from main grid
-        selections_grid.selections = self.selections
-        selections_grid.selection_mode = self.selection_mode
-
-        return SelectionHelper(grid=selections_grid).all_values()
+        return SelectionHelper(view_data_object, self.selections, self.selection_mode).all_values()
 
     @property
     def selected_cell_iterator(self):

--- a/ipydatagrid/datagrid.py
+++ b/ipydatagrid/datagrid.py
@@ -292,7 +292,7 @@ class DataGrid(DOMWidget):
     def __handle_custom_msg(self, _, content, buffers):  # noqa: U101,U100
         if content["event_type"] == "cell-changed":
             row = content["row"]
-            column = DataGrid._column_index_to_name(
+            column = self._column_index_to_name(
                 self._data, content["column_index"]
             )
             value = content["value"]
@@ -377,7 +377,7 @@ class DataGrid(DOMWidget):
         self.__dataframe_reference_columns = dataframe.columns
         dataframe = dataframe.copy()
 
-        self._data = DataGrid.generate_data_object(dataframe, "ipydguuid")
+        self._data = self.generate_data_object(dataframe, "ipydguuid")
 
     def get_cell_value(self, column_name, primary_key_value):
         """Gets the value for a single or multiple cells by column name and index name.
@@ -540,7 +540,7 @@ class DataGrid(DOMWidget):
         view_data = self.get_visible_data()
 
         # Serielize to JSON table schema
-        view_data_object = DataGrid.generate_data_object(view_data, "ipydguuid")
+        view_data_object = self.generate_data_object(view_data, "ipydguuid")
 
         return SelectionHelper(
             view_data_object, self.selections, self.selection_mode
@@ -651,7 +651,7 @@ class DataGrid(DOMWidget):
     def _column_name_to_index(self, column_name):
         if "schema" not in self._data or "fields" not in self._data["schema"]:
             return None
-        col_headers = DataGrid._get_col_headers(self._data)
+        col_headers = self._get_col_headers(self._data)
         try:
             return col_headers.index(column_name)
         except ValueError:

--- a/ipydatagrid/datagrid.py
+++ b/ipydatagrid/datagrid.py
@@ -110,7 +110,9 @@ class SelectionHelper:
         Returns values for all selected cells as a list.
         """
         return [
-            DataGrid._get_cell_value_by_numerical_index(self._data, cell["c"], cell["r"])
+            DataGrid._get_cell_value_by_numerical_index(
+                self._data, cell["c"], cell["r"]
+            )
             for cell in self
         ]
 
@@ -290,7 +292,9 @@ class DataGrid(DOMWidget):
     def __handle_custom_msg(self, _, content, buffers):  # noqa: U101,U100
         if content["event_type"] == "cell-changed":
             row = content["row"]
-            column = DataGrid._column_index_to_name(self._data, content["column_index"])
+            column = DataGrid._column_index_to_name(
+                self._data, content["column_index"]
+            )
             value = content["value"]
             # update data on kernel
             self._data["data"][row][column] = value
@@ -358,7 +362,6 @@ class DataGrid(DOMWidget):
             schema["primaryKey"].append(guid_key)
 
         schema["primaryKeyUuid"] = guid_key
-
 
         return {
             "data": data,
@@ -524,7 +527,9 @@ class DataGrid(DOMWidget):
         List of selected cells. Each cell is represented as a dictionary
         with keys 'r': row and 'c': column
         """
-        return SelectionHelper(self._data, self.selections, self.selection_mode).all()
+        return SelectionHelper(
+            self._data, self.selections, self.selection_mode
+        ).all()
 
     @property
     def selected_cell_values(self):
@@ -537,7 +542,9 @@ class DataGrid(DOMWidget):
         # Serielize to JSON table schema
         view_data_object = DataGrid.generate_data_object(view_data, "ipydguuid")
 
-        return SelectionHelper(view_data_object, self.selections, self.selection_mode).all_values()
+        return SelectionHelper(
+            view_data_object, self.selections, self.selection_mode
+        ).all_values()
 
     @property
     def selected_cell_iterator(self):

--- a/tests/test_datagrid.py
+++ b/tests/test_datagrid.py
@@ -15,6 +15,7 @@ def dataframe() -> None:
 def datagrid(dataframe) -> None:
     return DataGrid(dataframe)
 
+
 @pytest.fixture
 def data_object(dataframe) -> None:
     return DataGrid.generate_data_object(dataframe, "ipydguuid")
@@ -103,32 +104,51 @@ def test_get_cell_value_by_numerical_index(
     invalid_coords: bool, data_object: dict
 ) -> None:
     if invalid_coords:
-        assert DataGrid._get_cell_value_by_numerical_index(data_object, 2, 2) is None
+        assert (
+            DataGrid._get_cell_value_by_numerical_index(data_object, 2, 2)
+            is None
+        )
     else:
-        assert DataGrid._get_cell_value_by_numerical_index(data_object, 1, 0) == 4
+        assert (
+            DataGrid._get_cell_value_by_numerical_index(data_object, 1, 0) == 4
+        )
+
 
 def test_data_object_generation(dataframe: pd.DataFrame) -> None:
     data_object = DataGrid.generate_data_object(dataframe, "ipydguuid")
     expected_output = {
-        'data': [{'index': 'One', 'A': 1, 'B': 4, 'ipydguuid': 0},
-                {'index': 'Two', 'A': 2, 'B': 5, 'ipydguuid': 1},
-                {'index': 'Three', 'A': 3, 'B': 6, 'ipydguuid': 2}],
-        'schema': {'fields': [{'name': 'index', 'type': 'string'},
-                  {'name': 'A', 'type': 'integer'},
-                  {'name': 'B', 'type': 'integer'},
-                  {'name': 'ipydguuid', 'type': 'integer'}],
-                  'primaryKey': ['index', 'ipydguuid'],
-                  'pandas_version': '0.20.0',
-                  'primaryKeyUuid': 'ipydguuid'},
-        'fields': [{'index': None}, {'A': None}, {'B': None}, {'ipydguuid': None}]}
+        "data": [
+            {"index": "One", "A": 1, "B": 4, "ipydguuid": 0},
+            {"index": "Two", "A": 2, "B": 5, "ipydguuid": 1},
+            {"index": "Three", "A": 3, "B": 6, "ipydguuid": 2},
+        ],
+        "schema": {
+            "fields": [
+                {"name": "index", "type": "string"},
+                {"name": "A", "type": "integer"},
+                {"name": "B", "type": "integer"},
+                {"name": "ipydguuid", "type": "integer"},
+            ],
+            "primaryKey": ["index", "ipydguuid"],
+            "pandas_version": "0.20.0",
+            "primaryKeyUuid": "ipydguuid",
+        },
+        "fields": [
+            {"index": None},
+            {"A": None},
+            {"B": None},
+            {"ipydguuid": None},
+        ],
+    }
 
     assert data_object == expected_output
+
 
 def test_selected_cell_values(monkeypatch, datagrid, dataframe):
     # Mocking data returned from front-end
     def mock_get_visible_data():
         return dataframe
-    
+
     monkeypatch.setattr(datagrid, "get_visible_data", mock_get_visible_data)
     datagrid.select(1, 0, 2, 1)  # Select 1A to 2B
 

--- a/tests/test_datagrid.py
+++ b/tests/test_datagrid.py
@@ -106,3 +106,20 @@ def test_get_cell_value_by_numerical_index(
         assert DataGrid._get_cell_value_by_numerical_index(data_object, 2, 2) is None
     else:
         assert DataGrid._get_cell_value_by_numerical_index(data_object, 1, 0) == 4
+
+def test_data_object_generation(dataframe: pd.DataFrame) -> None:
+    data_object = DataGrid.generate_data_object(dataframe, "ipydguuid")
+    expected_output = {
+        'data': [{'index': 'One', 'A': 1, 'B': 4, 'ipydguuid': 0},
+                {'index': 'Two', 'A': 2, 'B': 5, 'ipydguuid': 1},
+                {'index': 'Three', 'A': 3, 'B': 6, 'ipydguuid': 2}],
+        'schema': {'fields': [{'name': 'index', 'type': 'string'},
+                  {'name': 'A', 'type': 'integer'},
+                  {'name': 'B', 'type': 'integer'},
+                  {'name': 'ipydguuid', 'type': 'integer'}],
+                  'primaryKey': ['index', 'ipydguuid'],
+                  'pandas_version': '0.20.0',
+                  'primaryKeyUuid': 'ipydguuid'},
+        'fields': [{'index': None}, {'A': None}, {'B': None}, {'ipydguuid': None}]}
+
+    assert data_object == expected_output

--- a/tests/test_datagrid.py
+++ b/tests/test_datagrid.py
@@ -15,6 +15,10 @@ def dataframe() -> None:
 def datagrid(dataframe) -> None:
     return DataGrid(dataframe)
 
+@pytest.fixture
+def data_object(dataframe) -> None:
+    return DataGrid.generate_data_object(dataframe, "ipydguuid")
+
 
 @pytest.mark.parametrize("clear", [True, False])
 def test_selections(clear: bool, dataframe: pd.DataFrame) -> None:
@@ -73,15 +77,15 @@ def test_column_name_to_index(invalid_index: bool, datagrid: DataGrid) -> None:
 
 
 @pytest.mark.parametrize("invalid_index", [True, False])
-def test_column_index_to_name(invalid_index: bool, datagrid: DataGrid) -> None:
+def test_column_index_to_name(invalid_index: bool, data_object: dict) -> None:
     if invalid_index:
-        assert datagrid._column_index_to_name(4) is None
+        assert DataGrid._column_index_to_name(data_object, 4) is None
     else:
-        assert datagrid._column_index_to_name(1) == "B"
+        assert DataGrid._column_index_to_name(data_object, 1) == "B"
 
 
-def test_get_col_headers(datagrid) -> None:
-    assert datagrid._get_col_headers() == ["A", "B"]
+def test_get_col_headers(data_object) -> None:
+    assert DataGrid._get_col_headers(data_object) == ["A", "B"]
 
 
 @pytest.mark.parametrize("invalid_prim_key", [True, False])
@@ -96,9 +100,9 @@ def test_get_row_index_of_primary_key(
 
 @pytest.mark.parametrize("invalid_coords", [True, False])
 def test_get_cell_value_by_numerical_index(
-    invalid_coords: bool, datagrid: DataGrid
+    invalid_coords: bool, data_object: dict
 ) -> None:
     if invalid_coords:
-        assert datagrid._get_cell_value_by_numerical_index(2, 2) is None
+        assert DataGrid._get_cell_value_by_numerical_index(data_object, 2, 2) is None
     else:
-        assert datagrid._get_cell_value_by_numerical_index(1, 0) == 4
+        assert DataGrid._get_cell_value_by_numerical_index(data_object, 1, 0) == 4

--- a/tests/test_datagrid.py
+++ b/tests/test_datagrid.py
@@ -123,3 +123,13 @@ def test_data_object_generation(dataframe: pd.DataFrame) -> None:
         'fields': [{'index': None}, {'A': None}, {'B': None}, {'ipydguuid': None}]}
 
     assert data_object == expected_output
+
+def test_selected_cell_values(monkeypatch, datagrid, dataframe):
+    # Mocking data returned from front-end
+    def mock_get_visible_data():
+        return dataframe
+    
+    monkeypatch.setattr(datagrid, "get_visible_data", mock_get_visible_data)
+    datagrid.select(1, 0, 2, 1)  # Select 1A to 2B
+
+    assert datagrid.selected_cell_values == [2, 5, 3, 6]


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #213 *

This is an iteration on #219 . We now separate the data model from the grid, allowing `SelectionHelper` to return selections based on JSON table schema objects. Also updated tests and added new ones.
