### PR TITLE
Fix build script so we include a dist folder with nbextension in build tarballs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ipydatagrid",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "clean:labextension": "rimraf ipydatagrid/labextension",
     "clean:nbextension": "rimraf ipydatagrid/nbextension/index.*",
     "lint": "eslint 'js/**/*.{js,ts}' --quiet --fix",
-    "prepack": "npm run build:lib",
+    "prepack": "npm run build:labextension && npm run build:nbextension",
     "test": "jest",
     "watch": "npm-run-all -p watch:*",
     "watch:lib": "tsc -w",


### PR DESCRIPTION
This PR changes the build script in `package.json` so that the resulting `npm pack`  tarball includes an nbextension bundle in a `dist` folder. This is needed for our published NPM package, which is relied on by `nbconvert` and `voila`. I'm also uploading an updated `package-lock.json` file which references version 1.0.4.
