### PR TITLE
Fix the `format` call in `vega-functions`

### DIFF
--- a/js/vegaexpr.ts
+++ b/js/vegaexpr.ts
@@ -15,9 +15,8 @@ import { MODULE_NAME, MODULE_VERSION } from './version';
 // manually create and bind that locale context to the format function.
 const locale = vegaFormat.defaultLocale();
 const dataflow = { context: { dataflow: { locale: () => locale } } };
-vegaFunctions.functionContext.format = vegaFunctions.functionContext.format.bind(
-  dataflow,
-);
+vegaFunctions.functionContext.format =
+  vegaFunctions.functionContext.format.bind(dataflow);
 
 export class VegaExprModel extends WidgetModel {
   defaults() {

--- a/js/vegaexpr.ts
+++ b/js/vegaexpr.ts
@@ -15,8 +15,9 @@ import { MODULE_NAME, MODULE_VERSION } from './version';
 // manually create and bind that locale context to the format function.
 const locale = vegaFormat.defaultLocale();
 const dataflow = { context: { dataflow: { locale: () => locale } } };
-vegaFunctions.functionContext.format =
-  vegaFunctions.functionContext.format.bind(dataflow);
+vegaFunctions.functionContext.format = vegaFunctions.functionContext.format.bind(
+  dataflow
+);
 
 export class VegaExprModel extends WidgetModel {
   defaults() {

--- a/js/vegaexpr.ts
+++ b/js/vegaexpr.ts
@@ -16,7 +16,7 @@ import { MODULE_NAME, MODULE_VERSION } from './version';
 const locale = vegaFormat.defaultLocale();
 const dataflow = { context: { dataflow: { locale: () => locale } } };
 vegaFunctions.functionContext.format = vegaFunctions.functionContext.format.bind(
-  dataflow
+  dataflow,
 );
 
 export class VegaExprModel extends WidgetModel {


### PR DESCRIPTION
Signed-off-by: Itay Dafna <i.b.dafna@gmail.com>

This PR fixes a regression we attempted fixing in #173, where the `format` function call from `vega-functions` results in an error due to an internal `dataflow` property missing.
