### PR TITLE
Add Styling/Themes

### DIFF
--- a/ipydatagrid/cellrenderer.py
+++ b/ipydatagrid/cellrenderer.py
@@ -35,7 +35,7 @@ class Expr(VegaExpr):
             [
                 Variable("cell", ["value", "row", "column", "metadata"]),
                 "default_value",
-                "index"
+                "index",
             ],
         )
 

--- a/ipydatagrid/cellrenderer.py
+++ b/ipydatagrid/cellrenderer.py
@@ -35,6 +35,7 @@ class Expr(VegaExpr):
             [
                 Variable("cell", ["value", "row", "column", "metadata"]),
                 "default_value",
+                "index"
             ],
         )
 

--- a/ipydatagrid/datagrid.py
+++ b/ipydatagrid/datagrid.py
@@ -268,7 +268,7 @@ class DataGrid(DOMWidget):
         header_selection_border_color : border color of headers intersecting with selected area at column or row
         cursor_fill_color : fill color of cursor
         cursor_border_color : border color of cursor
-        scroll_shadow : color parameters for scroll shadow (vertical and horizontal). Takes three paramaters. 
+        scroll_shadow : color parameters for scroll shadow (vertical and horizontal). Takes three paramaters.
             size : size of shadow in pixels
             color1 : gradient color 1
             color2 : gradient color 2

--- a/ipydatagrid/datagrid.py
+++ b/ipydatagrid/datagrid.py
@@ -281,7 +281,7 @@ class DataGrid(DOMWidget):
     selections = List(Dict()).tag(sync=True, **widget_serialization)
     editable = Bool(False).tag(sync=True)
     column_widths = Dict({}).tag(sync=True)
-    grid_style = Dict(allow_none=True).tag(sync=True)
+    grid_style = Dict(allow_none=True).tag(sync=True, **widget_serialization)
 
     def __init__(self, dataframe, **kwargs):
         self.data = dataframe

--- a/ipydatagrid/datagrid.py
+++ b/ipydatagrid/datagrid.py
@@ -234,6 +234,11 @@ class DataGrid(DOMWidget):
         Dict to specify custom column sizes
         The keys (strings) indicate the names of the columns
         The values (integers) indicate the widths
+    grid_style : Dict of {propertyName: string | VegaExpr | Dict}
+        Dict to specify global grid styles.
+        The keys (strings) indicate the styling property
+        The values (css color properties or Vega Expression) indicate the values
+        See below for all supported styling properties
 
     Accessors (not observable traitlets)
     ---------
@@ -244,6 +249,30 @@ class DataGrid(DOMWidget):
         List of values for all selected cells.
     selected_cell_iterator : iterator
         An iterator to traverse selected cells one by one.
+
+    Supported styling properties:
+        void_color : color of the area where the grid is not painted on the canvas
+        background_color : background color for all body cells
+        row_background_color : row-wise background color (can take a string or Vega Expression)
+        column_background_color : column-wise background color (can take a string of Vega Expression)
+        grid_line_color : color of both vertical and horizontal grid lines
+        vertical_grid_line_color : vertical grid line color
+        horizontal_grid_line_color : horizontal grid line color
+        header_background_color : background color for all non-body cells (index and columns)
+        header_grid_line_color : grid line color for all non-body cells (index and columns)
+        header_vertical_grid_line_color : vertical grid line color for all non-body cells
+        header_horizontal_grid_line_color : horizontal grid line color for all non-body cells
+        selection_fill_color : fill color of selected area
+        selection_border_color : border color of selected area
+        header_selection_fill_color : fill color of headers intersecting with selected area at column or row
+        header_selection_border_color : border color of headers intersecting with selected area at column or row
+        cursor_fill_color : fill color of cursor
+        cursor_border_color : border color of cursor
+        scroll_shadow : color parameters for scroll shadow (vertical and horizontal). Takes three paramaters. 
+            size : size of shadow in pixels
+            color1 : gradient color 1
+            color2 : gradient color 2
+            color3 : gradient color 3
     """
 
     _model_name = Unicode("DataGridModel").tag(sync=True)

--- a/ipydatagrid/datagrid.py
+++ b/ipydatagrid/datagrid.py
@@ -251,24 +251,34 @@ class DataGrid(DOMWidget):
         An iterator to traverse selected cells one by one.
 
     Supported styling properties:
-        void_color : color of the area where the grid is not painted on the canvas
+        void_color : color of the area where the grid is not painted
+            on the canvas
         background_color : background color for all body cells
-        row_background_color : row-wise background color (can take a string or Vega Expression)
-        column_background_color : column-wise background color (can take a string of Vega Expression)
+        row_background_color : row-wise background color (can take
+            a string or Vega Expression)
+        column_background_color : column-wise background color (can take a
+            string of Vega Expression)
         grid_line_color : color of both vertical and horizontal grid lines
         vertical_grid_line_color : vertical grid line color
         horizontal_grid_line_color : horizontal grid line color
-        header_background_color : background color for all non-body cells (index and columns)
-        header_grid_line_color : grid line color for all non-body cells (index and columns)
-        header_vertical_grid_line_color : vertical grid line color for all non-body cells
-        header_horizontal_grid_line_color : horizontal grid line color for all non-body cells
+        header_background_color : background color for all non-body cells
+            (index and columns)
+        header_grid_line_color : grid line color for all non-body
+            cells (index and columns)
+        header_vertical_grid_line_color : vertical grid line color
+            for all non-body cells
+        header_horizontal_grid_line_color : horizontal grid line color
+            for all non-body cells
         selection_fill_color : fill color of selected area
         selection_border_color : border color of selected area
-        header_selection_fill_color : fill color of headers intersecting with selected area at column or row
-        header_selection_border_color : border color of headers intersecting with selected area at column or row
+        header_selection_fill_color : fill color of headers intersecting with
+            selected area at column or row
+        header_selection_border_color : border color of headers
+            intersecting with selected area at column or row
         cursor_fill_color : fill color of cursor
         cursor_border_color : border color of cursor
-        scroll_shadow : color parameters for scroll shadow (vertical and horizontal). Takes three paramaters.
+        scroll_shadow : Dict of color parameters for scroll shadow (vertical and
+            horizontal). Takes three paramaters:
             size : size of shadow in pixels
             color1 : gradient color 1
             color2 : gradient color 2

--- a/ipydatagrid/datagrid.py
+++ b/ipydatagrid/datagrid.py
@@ -281,6 +281,7 @@ class DataGrid(DOMWidget):
     selections = List(Dict()).tag(sync=True, **widget_serialization)
     editable = Bool(False).tag(sync=True)
     column_widths = Dict({}).tag(sync=True)
+    grid_style = Dict(allow_none=True).tag(sync=True)
 
     def __init__(self, dataframe, **kwargs):
         self.data = dataframe

--- a/js/cellrenderer.ts
+++ b/js/cellrenderer.ts
@@ -245,6 +245,8 @@ export class TextRendererModel extends CellRendererModel {
   }
 
   get_attrs(): ICellRendererAttribute[] {
+    const gridStyle = this.get('grid_style');
+    console.log(gridStyle);
     return [
       { name: 'font', phosphorName: 'font', defaultValue: '12px sans-serif' },
       { name: 'text_wrap', phosphorName: 'wrapText', defaultValue: false },
@@ -262,7 +264,7 @@ export class TextRendererModel extends CellRendererModel {
       {
         name: 'background_color',
         phosphorName: 'backgroundColor',
-        defaultValue: Theme.getBackgroundColor(),
+        defaultValue: undefined,
       },
       {
         name: 'vertical_alignment',

--- a/js/cellrenderer.ts
+++ b/js/cellrenderer.ts
@@ -245,8 +245,6 @@ export class TextRendererModel extends CellRendererModel {
   }
 
   get_attrs(): ICellRendererAttribute[] {
-    const gridStyle = this.get('grid_style');
-    console.log(gridStyle);
     return [
       { name: 'font', phosphorName: 'font', defaultValue: '12px sans-serif' },
       { name: 'text_wrap', phosphorName: 'wrapText', defaultValue: false },
@@ -264,7 +262,7 @@ export class TextRendererModel extends CellRendererModel {
       {
         name: 'background_color',
         phosphorName: 'backgroundColor',
-        defaultValue: undefined,
+        defaultValue: Theme.getBackgroundColor(),
       },
       {
         name: 'vertical_alignment',

--- a/js/datagrid.ts
+++ b/js/datagrid.ts
@@ -424,7 +424,9 @@ export class DataGridView extends DOMWidgetView {
     this.model.on_some_change(
       ['header_renderer', 'default_renderer', 'renderers', 'grid_style'],
       () => {
-        this.updateRenderers().then(this.updateGridRenderers.bind(this));
+        this.updateRenderers()
+          .then(this.updateGridStyle.bind(this))
+          .then(this.updateGridRenderers.bind(this));
       },
       this,
     );

--- a/js/datagrid.ts
+++ b/js/datagrid.ts
@@ -357,6 +357,7 @@ export class DataGridView extends DOMWidgetView {
     this.grid.isLightTheme = this._isLightTheme;
     this.grid.dataModel = this.model.data_model;
     this.grid.selectionModel = this.model.selectionModel;
+    this.grid.backboneModel = this.model;
 
     this.grid.cellClicked.connect(
       (sender: FeatherGrid, event: FeatherGrid.ICellClickedEvent) => {
@@ -438,7 +439,7 @@ export class DataGridView extends DOMWidgetView {
     return this.updateRenderers().then(() => {
       this.updateGridStyle();
       this.updateGridRenderers();
-
+      this.grid.setGridStyle();
       this.pWidget.addWidget(this.grid);
     });
   }
@@ -518,6 +519,7 @@ export class DataGridView extends DOMWidgetView {
 
   public updateGridStyle() {
     this.grid.updateGridStyle();
+    this.grid.setGridStyle();
   }
 
   set isLightTheme(value: boolean) {
@@ -575,6 +577,7 @@ export class DataGridView extends DOMWidgetView {
   grid: FeatherGrid;
   pWidget: JupyterPhosphorPanelWidget;
   model: DataGridModel;
+  backboneModel: DataGridModel;
 
   // keep undefined since widget initializes before constructor
   private _isLightTheme: boolean;

--- a/js/datagrid.ts
+++ b/js/datagrid.ts
@@ -259,6 +259,28 @@ export class DataGridModel extends DOMWidgetModel {
 }
 
 /**
+ * Helper function to conver snake_case strings to camelCase.
+ * Assumes all strings are valid snake_case (all lowercase).
+ * @param string snake_case string
+ * @returns camelCase string
+ */
+function camelCase(string: string): string {
+  string = string.toLowerCase();
+  const charArray = [];
+  for (let i = 0; i < string.length; i++) {
+    const curChar = string.charAt(i);
+    if (curChar === '_') {
+      i++;
+      charArray.push(string.charAt(i).toUpperCase());
+      continue;
+    }
+    charArray.push(curChar);
+  }
+
+  return charArray.join('');
+}
+
+/**
  * Custom deserialization function for grid styles.
  */
 function unpack_style(
@@ -268,7 +290,7 @@ function unpack_style(
   if (value instanceof Object && typeof value !== 'string') {
     const unpacked: { [key: string]: any } = {};
     Object.keys(value).forEach((key) => {
-      unpacked[key] = unpack_style(value[key], manager);
+      unpacked[camelCase(key)] = unpack_style(value[key], manager);
     });
     return resolvePromisesDict(unpacked);
   } else if (typeof value === 'string' && value.slice(0, 10) === 'IPY_MODEL_') {

--- a/js/datagrid.ts
+++ b/js/datagrid.ts
@@ -59,6 +59,7 @@ export class DataGridModel extends DOMWidgetModel {
       header_renderer: null,
       selection_mode: 'none',
       selections: [],
+      grid_style: {},
       editable: false,
       column_widths: {},
     };
@@ -320,6 +321,7 @@ export class DataGridView extends DOMWidgetView {
         columnHeaderHeight: this.model.get('base_column_header_size'),
       },
       headerVisibility: this.model.get('header_visibility'),
+      style: this.model.get('grid_style'),
     });
 
     this.grid.columnWidths = this.model.get('column_widths');

--- a/js/datagrid.ts
+++ b/js/datagrid.ts
@@ -3,7 +3,7 @@
 
 import * as _ from 'underscore';
 
-import { BasicSelectionModel } from '@lumino/datagrid';
+import { BasicSelectionModel, TextRenderer } from '@lumino/datagrid';
 
 import { CellRenderer } from '@lumino/datagrid';
 
@@ -30,6 +30,7 @@ import { MODULE_NAME, MODULE_VERSION } from './version';
 
 import { CellRendererModel, CellRendererView } from './cellrenderer';
 import { FeatherGrid } from './feathergrid';
+import { Theme } from './utils';
 
 // Import CSS
 import '../style/jupyter-widget.css';
@@ -439,7 +440,6 @@ export class DataGridView extends DOMWidgetView {
     return this.updateRenderers().then(() => {
       this.updateGridStyle();
       this.updateGridRenderers();
-      this.grid.setGridStyle();
       this.pWidget.addWidget(this.grid);
     });
   }
@@ -519,7 +519,6 @@ export class DataGridView extends DOMWidgetView {
 
   public updateGridStyle() {
     this.grid.updateGridStyle();
-    this.grid.setGridStyle();
   }
 
   set isLightTheme(value: boolean) {
@@ -535,7 +534,20 @@ export class DataGridView extends DOMWidgetView {
   }
 
   private updateGridRenderers() {
-    const defaultRenderer = this.default_renderer.renderer;
+    let defaultRenderer = this.default_renderer.renderer;
+    if (
+      this.grid.grid.style.backgroundColor !== Theme.getBackgroundColor() ||
+      this.grid.grid.style.rowBackgroundColor ||
+      this.grid.grid.style.columnBackgroundColor
+    ) {
+      // Making sure the default renderer doesn't paint over the global
+      // grid background color, if the latter is set.
+      defaultRenderer = new TextRenderer({
+        ...this.default_renderer.renderer,
+        backgroundColor: undefined,
+      });
+    }
+
     let columnHeaderRenderer = null;
     if (this.header_renderer) {
       columnHeaderRenderer = this.header_renderer.renderer;

--- a/js/datagrid.ts
+++ b/js/datagrid.ts
@@ -420,7 +420,7 @@ export class DataGridView extends DOMWidgetView {
     });
 
     this.model.on_some_change(
-      ['header_renderer', 'default_renderer', 'renderers'],
+      ['header_renderer', 'default_renderer', 'renderers', 'grid_style'],
       () => {
         this.updateRenderers().then(this.updateGridRenderers.bind(this));
       },

--- a/js/feathergrid.ts
+++ b/js/feathergrid.ts
@@ -525,7 +525,7 @@ export class FeatherGrid extends Widget {
     this._updateColumnWidths();
   }
 
-  public setGridStyle() {
+  public setGridStyle(): void {
     // Resetting grid style if theme changes.
     if (this.backboneModel) {
       this.grid.style = this.backboneModel.get('grid_style');
@@ -573,7 +573,7 @@ export class FeatherGrid extends Widget {
     };
   }
 
-  public updateGridStyle() {
+  public updateGridStyle(): void {
     this.setGridStyle();
     this._updateHeaderRenderer();
 

--- a/js/feathergrid.ts
+++ b/js/feathergrid.ts
@@ -20,6 +20,8 @@ import { Transform } from './core/transform';
 import { Theme } from './utils';
 import { KeyHandler } from './keyhandler';
 
+import { DataGridModel as BackBoneModel } from './datagrid';
+
 import '@lumino/default-theme/style/datagrid.css';
 import '../style/feathergrid.css';
 
@@ -518,39 +520,16 @@ export class FeatherGrid extends Widget {
     this.updateGridStyle();
     this._updateGridRenderers();
     this._updateColumnWidths();
+    this.setGridStyle();
   }
 
-  public updateGridStyle() {
-    this._updateHeaderRenderer();
-
-    if (!this._defaultRendererSet) {
-      this._defaultRenderer = new TextRenderer({
-        font: '12px sans-serif',
-        textColor: Theme.getFontColor(),
-        backgroundColor: Theme.getBackgroundColor(),
-        horizontalAlignment: 'left',
-        verticalAlignment: 'center',
-      });
+  public setGridStyle() {
+    // Resetting grid style if theme changes.
+    if (this.backboneModel) {
+      this.grid.style = this.backboneModel.get('grid_style');
     }
 
-    this._rowHeaderRenderer = new TextRenderer({
-      textColor: Theme.getFontColor(1),
-      backgroundColor: Theme.getBackgroundColor(2),
-      horizontalAlignment: 'center',
-      verticalAlignment: 'center',
-    });
-
-    this._columnHeaderRenderer = new HeaderRenderer({
-      textOptions: {
-        textColor: Theme.getFontColor(1),
-        backgroundColor: Theme.getBackgroundColor(2),
-        horizontalAlignment: 'left',
-        verticalAlignment: 'center',
-      },
-      isLightTheme: this._isLightTheme,
-      grid: this.grid,
-    });
-
+    // Setting up theme.
     const scrollShadow = {
       size: 4,
       color1: Theme.getBorderColor(1, 1.0),
@@ -590,6 +569,40 @@ export class FeatherGrid extends Widget {
         this.grid.style.cursorBorderColor || Theme.getBrandColor(1),
       scrollShadow: this.grid.style.scrollShadow || scrollShadow,
     };
+  }
+
+  public updateGridStyle() {
+    this._updateHeaderRenderer();
+
+    if (!this._defaultRendererSet) {
+      this._defaultRenderer = new TextRenderer({
+        font: '12px sans-serif',
+        textColor: Theme.getFontColor(),
+        backgroundColor: Theme.getBackgroundColor(),
+        horizontalAlignment: 'left',
+        verticalAlignment: 'center',
+      });
+    }
+
+    this._rowHeaderRenderer = new TextRenderer({
+      textColor: Theme.getFontColor(1),
+      backgroundColor: Theme.getBackgroundColor(2),
+      horizontalAlignment: 'center',
+      verticalAlignment: 'center',
+    });
+
+    this._columnHeaderRenderer = new HeaderRenderer({
+      textOptions: {
+        textColor: Theme.getFontColor(1),
+        backgroundColor: Theme.getBackgroundColor(2),
+        horizontalAlignment: 'left',
+        verticalAlignment: 'center',
+      },
+      isLightTheme: this._isLightTheme,
+      grid: this.grid,
+    });
+
+    this.setGridStyle();
   }
 
   copyToClipboard(): void {
@@ -1014,6 +1027,7 @@ export class FeatherGrid extends Widget {
   private _cellClicked = new Signal<this, FeatherGrid.ICellClickedEvent>(this);
   private _columnsResized = new Signal<this, void>(this);
   private _isLightTheme = true;
+  backboneModel: BackBoneModel;
 }
 
 /**

--- a/js/feathergrid.ts
+++ b/js/feathergrid.ts
@@ -559,17 +559,36 @@ export class FeatherGrid extends Widget {
     };
 
     this.grid.style = {
-      voidColor: Theme.getBackgroundColor(),
-      backgroundColor: Theme.getBackgroundColor(),
-      gridLineColor: Theme.getBorderColor(),
-      headerGridLineColor: Theme.getBorderColor(1),
-      selectionFillColor: Theme.getBrandColor(2, 0.4),
-      selectionBorderColor: Theme.getBrandColor(1),
-      headerSelectionFillColor: Theme.getBackgroundColor(3, 0.4),
-      headerSelectionBorderColor: Theme.getBorderColor(1),
-      cursorFillColor: Theme.getBrandColor(3, 0.4),
-      cursorBorderColor: Theme.getBrandColor(1),
-      scrollShadow: scrollShadow,
+      voidColor: this.grid.style.voidColor || Theme.getBackgroundColor(),
+      backgroundColor:
+        this.grid.style.backgroundColor || Theme.getBackgroundColor(),
+      rowBackgroundColor: this.grid.style.rowBackgroundColor || undefined,
+      columnBackgroundColor: this.grid.style.columnBackgroundColor || undefined,
+      gridLineColor: this.grid.style.gridLineColor || Theme.getBorderColor(),
+      verticalGridLineColor: this.grid.style.verticalGridLineColor || undefined,
+      horizontalGridLineColor:
+        this.grid.style.horizontalGridLineColor || undefined,
+      headerBackgroundColor: this.grid.style.headerBackgroundColor || undefined,
+      headerGridLineColor:
+        this.grid.style.headerGridLineColor || Theme.getBorderColor(1),
+      headerVerticalGridLineColor:
+        this.grid.style.headerVerticalGridLineColor || undefined,
+      headerHorizontalGridLineColor:
+        this.grid.style.headerHorizontalGridLineColor || undefined,
+      selectionFillColor:
+        this.grid.style.selectionFillColor || Theme.getBrandColor(2, 0.4),
+      selectionBorderColor:
+        this.grid.style.headerSelectionBorderColor || Theme.getBrandColor(1),
+      headerSelectionFillColor:
+        this.grid.style.headerSelectionFillColor ||
+        Theme.getBackgroundColor(3, 0.4),
+      headerSelectionBorderColor:
+        this.grid.style.headerSelectionBorderColor || Theme.getBorderColor(1),
+      cursorFillColor:
+        this.grid.style.cursorFillColor || Theme.getBrandColor(3, 0.4),
+      cursorBorderColor:
+        this.grid.style.cursorBorderColor || Theme.getBrandColor(1),
+      scrollShadow: this.grid.style.scrollShadow || scrollShadow,
     };
   }
 

--- a/js/feathergrid.ts
+++ b/js/feathergrid.ts
@@ -1012,6 +1012,7 @@ export class FeatherGrid extends Widget {
   }
 
   grid: DataGrid;
+  backboneModel: BackBoneModel;
   contextMenu: FeatherGridContextMenu;
   private _filterDialog: InteractiveFilterDialog;
   private _baseRowSize = 20;
@@ -1031,7 +1032,6 @@ export class FeatherGrid extends Widget {
   private _cellClicked = new Signal<this, FeatherGrid.ICellClickedEvent>(this);
   private _columnsResized = new Signal<this, void>(this);
   private _isLightTheme = true;
-  backboneModel: BackBoneModel;
 }
 
 /**

--- a/js/feathergrid.ts
+++ b/js/feathergrid.ts
@@ -217,14 +217,16 @@ export class FeatherGrid extends Widget {
     this._defaultRenderer = new TextRenderer({
       font: '12px sans-serif',
       textColor: Theme.getFontColor(),
-      backgroundColor: Theme.getBackgroundColor(),
+      backgroundColor:
+        this.grid.style.backgroundColor || Theme.getBackgroundColor(),
       horizontalAlignment: 'center',
       verticalAlignment: 'center',
     });
 
     this._rowHeaderRenderer = new TextRenderer({
       textColor: Theme.getFontColor(1),
-      backgroundColor: Theme.getBackgroundColor(2),
+      backgroundColor:
+        this.grid.style.headerBackgroundColor || Theme.getBackgroundColor(2),
       horizontalAlignment: 'center',
       verticalAlignment: 'center',
     });
@@ -392,15 +394,17 @@ export class FeatherGrid extends Widget {
   set columnHeaderRenderer(renderer: CellRenderer) {
     const textRenderer = renderer as TextRenderer;
 
-    // Need to create a HeadeRenderer object as TextRenderer
-    // objects do not support merged cell rendering.
+    // HeaderRenderer adds the filter dialogue box overlay
     this._columnHeaderRenderer = new HeaderRenderer({
       textOptions: {
         font: textRenderer.font,
         wrapText: textRenderer.wrapText,
         elideDirection: textRenderer.elideDirection,
         textColor: textRenderer.textColor,
-        backgroundColor: textRenderer.backgroundColor,
+        backgroundColor:
+          this.grid.style.headerBackgroundColor ||
+          textRenderer.backgroundColor ||
+          Theme.getBackgroundColor(),
         verticalAlignment: textRenderer.verticalAlignment,
         horizontalAlignment: textRenderer.horizontalAlignment,
         format: textRenderer.format,
@@ -492,7 +496,6 @@ export class FeatherGrid extends Widget {
     this.grid.copyToClipboard = this.copyToClipboard.bind(this.grid);
 
     this.grid.dataModel = this._dataModel;
-    //@ts-ignore **added so we can remove basickeyhandler.ts from fork
     this.grid.keyHandler = new KeyHandler();
     const mouseHandler = new FeatherGridMouseHandler(this);
     mouseHandler.cellClicked.connect(
@@ -512,7 +515,7 @@ export class FeatherGrid extends Widget {
         });
       },
     );
-    //@ts-ignore added so we don't have to add basicmousehandler.ts fork
+
     this.grid.mouseHandler = mouseHandler;
     this.grid.selectionModel = this._selectionModel;
     this.grid.editingEnabled = this._editable;
@@ -520,7 +523,6 @@ export class FeatherGrid extends Widget {
     this.updateGridStyle();
     this._updateGridRenderers();
     this._updateColumnWidths();
-    this.setGridStyle();
   }
 
   public setGridStyle() {
@@ -557,7 +559,7 @@ export class FeatherGrid extends Widget {
       selectionFillColor:
         this.grid.style.selectionFillColor || Theme.getBrandColor(2, 0.4),
       selectionBorderColor:
-        this.grid.style.headerSelectionBorderColor || Theme.getBrandColor(1),
+        this.grid.style.selectionBorderColor || Theme.getBrandColor(1),
       headerSelectionFillColor:
         this.grid.style.headerSelectionFillColor ||
         Theme.getBackgroundColor(3, 0.4),
@@ -572,13 +574,15 @@ export class FeatherGrid extends Widget {
   }
 
   public updateGridStyle() {
+    this.setGridStyle();
     this._updateHeaderRenderer();
 
     if (!this._defaultRendererSet) {
-      this._defaultRenderer = new TextRenderer({
+      this.defaultRenderer = new TextRenderer({
         font: '12px sans-serif',
         textColor: Theme.getFontColor(),
-        backgroundColor: Theme.getBackgroundColor(),
+        backgroundColor:
+          this.grid.style.backgroundColor || Theme.getBackgroundColor(),
         horizontalAlignment: 'left',
         verticalAlignment: 'center',
       });
@@ -586,7 +590,8 @@ export class FeatherGrid extends Widget {
 
     this._rowHeaderRenderer = new TextRenderer({
       textColor: Theme.getFontColor(1),
-      backgroundColor: Theme.getBackgroundColor(2),
+      backgroundColor:
+        this.grid.style.headerBackgroundColor || Theme.getBackgroundColor(2),
       horizontalAlignment: 'center',
       verticalAlignment: 'center',
     });
@@ -594,15 +599,14 @@ export class FeatherGrid extends Widget {
     this._columnHeaderRenderer = new HeaderRenderer({
       textOptions: {
         textColor: Theme.getFontColor(1),
-        backgroundColor: Theme.getBackgroundColor(2),
+        backgroundColor:
+          this.grid.style.headerBackgroundColor || Theme.getBackgroundColor(2),
         horizontalAlignment: 'left',
         verticalAlignment: 'center',
       },
       isLightTheme: this._isLightTheme,
       grid: this.grid,
     });
-
-    this.setGridStyle();
   }
 
   copyToClipboard(): void {


### PR DESCRIPTION
Signed-off-by: Itay Dafna <i.b.dafna@gmail.com>

This PR adds styling/theming support for `ipydatagrid` by exposing some styling properties `lumino/datagrid` has available. There is some overlap with properties such as `backgroundColor` which can also be set by `TextRenderer`, but overall it does allow for more customisation of the grid's style by enabling setting style properties such as grid lines, etc.

We will add the following styles:
```python
import pandas as pd
import numpy as np
import ipydatagrid as g

np.random.seed(104)
rang = 20
df = pd.DataFrame(
    data=[np.random.randint(0, 11, rang) for i in range(rang)],
    index=[f'Row {i}' for i in range(rang)],
    columns=[f'Col {i}' for i in range(rang)]
)

style = {
    'voidColor': '#111',
    'backgroundColor': 'purple',
#     'rowBackgroundColor': 'green', // Needs a function (vegaExpr?)
#     'columnBackgroundColor': 'yellow' // Needs a function (vegaExpr?)
      'gridLineColor': 'red',
     'verticalGridLineColor': 'navy',
     'horizontalGridLineColor': 'purple',
     'headerBackgroundColor': 'orange',
     'headerGridLineColor': 'green',
     'headerVerticalGridLineColor': 'yellow',
     'headerHorizontalGridLineColor': 'orange',
     'selectionFillColor': 'yellow',
     'selectionBorderColor': 'limegreen',
     'headerSelectionFillColor': 'darkorange',
      'headerSelectionBorderColor': 'green',
      'cursorFillColor': 'magenta',
      'cursorBorderColor': 'limegreen',
      'scrollShadow': {
          'size': 8,
          'color1': 'salmon',
          'color2': 'pink',
          'color3': 'gray'
      }
}

g.DataGrid(df, layout={'height': '300px'}, selection_mode='cell', grid_style=style)
```

*** PLEASE EXCUSE THE HIDEOUS STYLING HERE - THIS IS JUST FOR DEMO PURPOSES 🙈 🙉 🙊 ***
![image](https://user-images.githubusercontent.com/24281433/126117647-6c0e06e5-6de4-46cc-9b2d-c9c146a108b6.png)

I will map all properties so that we use snake_case on the Python side for consistency. I would like to keep this as simple as possible and allow the users to just pass a dictionary with these properties. Properties which are specified will take precedence over any defaults or values set in `TextRenderer/BarRenderer`, otherwise we fall back to the existing behaviour. 

Two of the properties here, `rowBackgroundColor` and `columnBackgroundColor` actually take a function `(index: number) => string`. @martinRenou I am thinking VegaExpr would be perfect here. We just need to whitelist the `index` arguments and hopefully it should work, what are your thoughts? How would this work when using `VegaExpr/Expr` as one of the values mapped to by a key in the `Dict()` traitlet? If there's a way to achieve this then great, otherwise we can create a `Theme` class which will have all these styles as properties with `Union(Dict(), Instance(VegaExpr))`.

EDIT: Would also make sense to use `Dict()` with keys mapping to `Color()` traitlets.
