### PR TITLE
Add support for corner header renderer

### DIFF
--- a/examples/Nested Hierarchies.ipynb
+++ b/examples/Nested Hierarchies.ipynb
@@ -11,25 +11,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "ultimate-supply",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "31962ad4cb6444afb7ce9f19ed7b384f",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "DataGrid(base_column_header_size=35, base_column_size=80, base_row_header_size=80, default_renderer=TextRender…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "import ipydatagrid as ipg\n",
     "import pandas as pd\n",

--- a/ipydatagrid/datagrid.py
+++ b/ipydatagrid/datagrid.py
@@ -216,6 +216,8 @@ class DataGrid(DOMWidget):
         Default renderer to use for cell rendering
     header_renderer : CellRenderer (default: TextRenderer)
         Renderer to use for header cell rendering
+    corner_renderer : CellRenderer (default: TextRenderer)
+        Renderer to use for corner header cell rendering
     selection_mode : {'row', 'column', 'cell', 'none'} (default: 'none')
         Selection mode used when user clicks on grid or makes selections
         programmatically.
@@ -312,6 +314,9 @@ class DataGrid(DOMWidget):
         sync=True, **widget_serialization
     )
     header_renderer = Instance(CellRenderer, allow_none=True).tag(
+        sync=True, **widget_serialization
+    )
+    corner_renderer = Instance(CellRenderer, allow_none=True).tag(
         sync=True, **widget_serialization
     )
     selection_mode = Enum(

--- a/js/datagrid.ts
+++ b/js/datagrid.ts
@@ -600,9 +600,16 @@ export class DataGridView extends DOMWidgetView {
       });
     }
 
+    const hasHeaderRenderer = this.model.get('header_renderer') !== null;
     let columnHeaderRenderer = null;
-    if (this.header_renderer) {
+    if (this.header_renderer && hasHeaderRenderer) {
       columnHeaderRenderer = this.header_renderer.renderer;
+    } else {
+      columnHeaderRenderer = new TextRenderer({
+        font: '12px sans-serif',
+        textColor: Theme.getFontColor(),
+        backgroundColor: Theme.getBackgroundColor(2),
+      });
     }
 
     let cornerHeaderRenderer = null;
@@ -616,10 +623,7 @@ export class DataGridView extends DOMWidgetView {
     });
 
     this.grid.defaultRenderer = defaultRenderer;
-    // Set column header renderer only if received from backend
-    if (columnHeaderRenderer) {
-      this.grid.columnHeaderRenderer = columnHeaderRenderer;
-    }
+    this.grid.columnHeaderRenderer = columnHeaderRenderer;
 
     if (cornerHeaderRenderer) {
       this.grid.cornerHeaderRenderer = cornerHeaderRenderer;

--- a/js/feathergrid.ts
+++ b/js/feathergrid.ts
@@ -424,6 +424,39 @@ export class FeatherGrid extends Widget {
     return this._columnHeaderRenderer;
   }
 
+  set cornerHeaderRenderer(renderer: CellRenderer) {
+    const textRenderer = renderer as TextRenderer;
+
+    // HeaderRenderer adds the filter dialogue box overlay
+    this._cornerHeaderRenderer = new HeaderRenderer({
+      textOptions: {
+        font: textRenderer.font,
+        wrapText: textRenderer.wrapText,
+        elideDirection: textRenderer.elideDirection,
+        textColor: textRenderer.textColor,
+        backgroundColor:
+          this.grid.style.headerBackgroundColor ||
+          textRenderer.backgroundColor ||
+          Theme.getBackgroundColor(),
+        verticalAlignment: textRenderer.verticalAlignment,
+        horizontalAlignment: textRenderer.horizontalAlignment,
+        format: textRenderer.format,
+      },
+      isLightTheme: this._isLightTheme,
+      grid: this.grid,
+    });
+
+    if (!this.grid) {
+      return;
+    }
+
+    this._updateHeaderRenderer();
+  }
+
+  get cornerHeaderRenderer(): CellRenderer {
+    return this._cornerHeaderRenderer;
+  }
+
   set renderers(renderers: Dict<CellRenderer>) {
     this._renderers = renderers;
 
@@ -597,6 +630,18 @@ export class FeatherGrid extends Widget {
     });
 
     this._columnHeaderRenderer = new HeaderRenderer({
+      textOptions: {
+        textColor: Theme.getFontColor(1),
+        backgroundColor:
+          this.grid.style.headerBackgroundColor || Theme.getBackgroundColor(2),
+        horizontalAlignment: 'left',
+        verticalAlignment: 'center',
+      },
+      isLightTheme: this._isLightTheme,
+      grid: this.grid,
+    });
+
+    this._cornerHeaderRenderer = new HeaderRenderer({
       textOptions: {
         textColor: Theme.getFontColor(1),
         backgroundColor:
@@ -893,9 +938,17 @@ export class FeatherGrid extends Widget {
     this.grid.cellRenderers.update({
       'column-header': this._columnHeaderRenderer,
     });
-    // Treating corner header as column header for rendering purposes
+    // Treating corner-header as column-header if a value has not
+    // been passed for the former.
+    let hasCornerRenderer = false;
+    if (this.backboneModel) {
+      hasCornerRenderer = this.backboneModel.get('corner_renderer') !== null;
+    }
+
     this.grid.cellRenderers.update({
-      'corner-header': this._columnHeaderRenderer,
+      'corner-header': hasCornerRenderer
+        ? this._cornerHeaderRenderer
+        : this._columnHeaderRenderer,
     });
   }
 
@@ -1027,6 +1080,7 @@ export class FeatherGrid extends Widget {
   private _renderers: Dict<CellRenderer> = {};
   private _defaultRenderer: CellRenderer;
   private _columnHeaderRenderer: CellRenderer;
+  private _cornerHeaderRenderer: CellRenderer;
   private _rowHeaderRenderer: CellRenderer;
   private _defaultRendererSet = false;
   private _cellClicked = new Signal<this, FeatherGrid.ICellClickedEvent>(this);

--- a/js/feathergrid.ts
+++ b/js/feathergrid.ts
@@ -608,7 +608,6 @@ export class FeatherGrid extends Widget {
 
   public updateGridStyle(): void {
     this.setGridStyle();
-    this._updateHeaderRenderer();
 
     if (!this._defaultRendererSet) {
       this.defaultRenderer = new TextRenderer({
@@ -652,6 +651,8 @@ export class FeatherGrid extends Widget {
       isLightTheme: this._isLightTheme,
       grid: this.grid,
     });
+
+    this._updateHeaderRenderer();
   }
 
   copyToClipboard(): void {

--- a/tests/js/datagrid.test.ts
+++ b/tests/js/datagrid.test.ts
@@ -129,7 +129,7 @@ describe('Test trait: data', () => {
     ).toEqual(oldTransforms);
   });
 
-  test('HeaderRenderer updated with reference to new model', async () => {
+  test('HeaderRenderer keeps same data model ref on data change (same model, new data)', async () => {
     const testData = Private.createBasicTestData();
     const grid = await Private.createGridWidget({
       data: testData.set1,
@@ -137,15 +137,13 @@ describe('Test trait: data', () => {
     });
     const cornerCellConfig = Private.createCellConfig('corner-header');
     const columnCellConfig = Private.createCellConfig('column-header');
-    const oldColHead = grid.view.grid.cellRenderers.get(cornerCellConfig);
-    const oldCornerHead = grid.view.grid.cellRenderers.get(columnCellConfig);
+    const oldCornerHead = grid.view.grid.cellRenderers.get(cornerCellConfig);
+    const oldColHead = grid.view.grid.cellRenderers.get(columnCellConfig);
     grid.model.set('_data', testData.set2);
-    expect(grid.view.grid.cellRenderers.get(cornerCellConfig)).not.toBe(
+    expect(grid.view.grid.cellRenderers.get(cornerCellConfig)).toBe(
       oldCornerHead,
     );
-    expect(grid.view.grid.cellRenderers.get(columnCellConfig)).not.toBe(
-      oldColHead,
-    );
+    expect(grid.view.grid.cellRenderers.get(columnCellConfig)).toBe(oldColHead);
   });
 
   test('Correct index of the grid is determined from column name', async () => {


### PR DESCRIPTION
Signed-off-by: Itay Dafna <i.b.dafna@gmail.com>

This PR adds support for corner header renderers via a `corner_renderer` traitlet. The current API behaviour is not changed - users who do not pass to the constructor or set the `corner_renderer` property on the `DataGrid` object, but do pass `header_renderer` will see the header renderer applied to the corner header too. If they do set a `corner_renderer` property then it will will override the header renderer - only applies to the corner header!

![image](https://user-images.githubusercontent.com/24281433/127268515-47e75751-15b9-4040-bbe6-f787b4127f43.png)

```python
import ipydatagrid as grid
import numpy as np
import pandas as pd

np.random.seed(565)
columns = [f'Col {x}' for x in "A B C D E F".split()]
index = [f'Row {x}' for x in range(1, 11)]
data = np.round(np.random.random((10, 6)), 2)
df = pd.DataFrame(index=index, columns=columns, data=data)

corner_renderer = grid.TextRenderer(
    background_color="yellow"
)
header_renderer = grid.TextRenderer(
    background_color="green"
)

index_rend = grid.TextRenderer(
    background_color='lawngreen'
)

g = grid.DataGrid(df, layout={'height':'250px'},
                  corner_renderer=corner_renderer,
                  header_renderer=header_renderer,
                  renderers={
                      'index':index_rend
                  }
                 )
g
```
