### PR TITLE
Invalid LICENSE link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Before sending a [Pull Request](../../pulls), please make sure you read our
 
 ## License
 
-Please read the [LICENSE](LICENSE) file.
+Please read the [LICENSE](LICENSE.txt) file.
 
 ## Code of Conduct
 


### PR DESCRIPTION

*Issue number of the reported bug or feature request: None*

**Describe your changes**
404 error when clicking on license web link from GitHub README

**Testing performed**
The link work on my fork 

**Additional context**
Congrats for this widget
