### PR TITLE
handle pandas NA #257

### DIFF
--- a/ipydatagrid/datagrid.py
+++ b/ipydatagrid/datagrid.py
@@ -178,6 +178,8 @@ def _data_to_json(x, obj):
                 return "$NegInfinity$"
         elif x is pd.NaT:
             return "$NaT$"
+        elif pd.isna(x):
+            return "$NA$"
         return x
 
 

--- a/ipydatagrid/datagrid.py
+++ b/ipydatagrid/datagrid.py
@@ -179,7 +179,7 @@ def _data_to_json(x, obj):
         elif x is pd.NaT:
             return "$NaT$"
         elif pd.isna(x):
-            return "$NA$"
+            return "$NaN$"
         return x
 
 


### PR DESCRIPTION
Pandas provides it's own 'NA' object for cases where numpy NaN is not appropriate (e.g. string columns). This is not currently handled in _data_to_json (only pandas NaT values are handled).

Addresses #257 

**Testing performed**
Testing still in progress - need to set up testing
