### PR TITLE
Add index_name parameter, use 'key' as default index name

### DIFF
--- a/ipydatagrid/datagrid.py
+++ b/ipydatagrid/datagrid.py
@@ -378,6 +378,22 @@ class DataGrid(DOMWidget):
     @staticmethod
     def generate_data_object(dataframe, guid_key="ipydguuid"):
         dataframe[guid_key] = pd.RangeIndex(0, dataframe.shape[0])
+        
+        # Renaming default index name from 'index' to 'id' on 
+        # single index DataFrames. This allows users to use
+        # 'index' as a column name. If 'id' exists, we add _x
+        # suffix to id, where { x | 0 <= x <= inf }
+        if not isinstance(dataframe.index, pd.MultiIndex):
+            if "id" in dataframe.columns:
+                index = 0
+                new_index_name = f'id_{index}'
+                while new_index_name in dataframe.columns:
+                    index += 1
+                    new_index_name = f'id_{index}'
+                dataframe = dataframe.rename_axis(new_index_name)
+            else:
+                dataframe = dataframe.rename_axis("id")
+
         schema = pd.io.json.build_table_schema(dataframe)
         reset_index_dataframe = dataframe.reset_index()
         data = reset_index_dataframe.to_dict(orient="records")

--- a/ipydatagrid/datagrid.py
+++ b/ipydatagrid/datagrid.py
@@ -378,18 +378,18 @@ class DataGrid(DOMWidget):
     @staticmethod
     def generate_data_object(dataframe, guid_key="ipydguuid"):
         dataframe[guid_key] = pd.RangeIndex(0, dataframe.shape[0])
-        
-        # Renaming default index name from 'index' to 'id' on 
+
+        # Renaming default index name from 'index' to 'id' on
         # single index DataFrames. This allows users to use
         # 'index' as a column name. If 'id' exists, we add _x
         # suffix to id, where { x | 0 <= x <= inf }
         if not isinstance(dataframe.index, pd.MultiIndex):
             if "id" in dataframe.columns:
                 index = 0
-                new_index_name = f'id_{index}'
+                new_index_name = f"id_{index}"
                 while new_index_name in dataframe.columns:
                     index += 1
-                    new_index_name = f'id_{index}'
+                    new_index_name = f"id_{index}"
                 dataframe = dataframe.rename_axis(new_index_name)
             else:
                 dataframe = dataframe.rename_axis("id")

--- a/tests/test_datagrid.py
+++ b/tests/test_datagrid.py
@@ -18,7 +18,7 @@ def datagrid(dataframe) -> None:
 
 @pytest.fixture
 def data_object(dataframe) -> None:
-    return DataGrid.generate_data_object(dataframe, "ipydguuid")
+    return DataGrid.generate_data_object(dataframe, "ipydguuid", "key")
 
 
 @pytest.mark.parametrize("clear", [True, False])
@@ -115,26 +115,26 @@ def test_get_cell_value_by_numerical_index(
 
 
 def test_data_object_generation(dataframe: pd.DataFrame) -> None:
-    data_object = DataGrid.generate_data_object(dataframe, "ipydguuid")
+    data_object = DataGrid.generate_data_object(dataframe, "ipydguuid", "key")
     expected_output = {
         "data": [
-            {"id": "One", "A": 1, "B": 4, "ipydguuid": 0},
-            {"id": "Two", "A": 2, "B": 5, "ipydguuid": 1},
-            {"id": "Three", "A": 3, "B": 6, "ipydguuid": 2},
+            {"key": "One", "A": 1, "B": 4, "ipydguuid": 0},
+            {"key": "Two", "A": 2, "B": 5, "ipydguuid": 1},
+            {"key": "Three", "A": 3, "B": 6, "ipydguuid": 2},
         ],
         "schema": {
             "fields": [
-                {"name": "id", "type": "string"},
+                {"name": "key", "type": "string"},
                 {"name": "A", "type": "integer"},
                 {"name": "B", "type": "integer"},
                 {"name": "ipydguuid", "type": "integer"},
             ],
-            "primaryKey": ["id", "ipydguuid"],
+            "primaryKey": ["key", "ipydguuid"],
             "pandas_version": "0.20.0",
             "primaryKeyUuid": "ipydguuid",
         },
         "fields": [
-            {"id": None},
+            {"key": None},
             {"A": None},
             {"B": None},
             {"ipydguuid": None},

--- a/tests/test_datagrid.py
+++ b/tests/test_datagrid.py
@@ -118,23 +118,23 @@ def test_data_object_generation(dataframe: pd.DataFrame) -> None:
     data_object = DataGrid.generate_data_object(dataframe, "ipydguuid")
     expected_output = {
         "data": [
-            {"index": "One", "A": 1, "B": 4, "ipydguuid": 0},
-            {"index": "Two", "A": 2, "B": 5, "ipydguuid": 1},
-            {"index": "Three", "A": 3, "B": 6, "ipydguuid": 2},
+            {"id": "One", "A": 1, "B": 4, "ipydguuid": 0},
+            {"id": "Two", "A": 2, "B": 5, "ipydguuid": 1},
+            {"id": "Three", "A": 3, "B": 6, "ipydguuid": 2},
         ],
         "schema": {
             "fields": [
-                {"name": "index", "type": "string"},
+                {"name": "id", "type": "string"},
                 {"name": "A", "type": "integer"},
                 {"name": "B", "type": "integer"},
                 {"name": "ipydguuid", "type": "integer"},
             ],
-            "primaryKey": ["index", "ipydguuid"],
+            "primaryKey": ["id", "ipydguuid"],
             "pandas_version": "0.20.0",
             "primaryKeyUuid": "ipydguuid",
         },
         "fields": [
-            {"index": None},
+            {"id": None},
             {"A": None},
             {"B": None},
             {"ipydguuid": None},


### PR DESCRIPTION
Signed-off-by: Itay Dafna <i.b.dafna@gmail.com>

Addresses two issues: #250 and #118 

When dealing with dataframes with index objects which are not `pandas.MultiIndex`, we now rename the default index name from 'index' to 'id' before applying `dataframe.reset_index()`. This ensures that the reserved 'index' keyword does not cause issues with numpy, and also allows users to use 'index' as a column name if they wish to do so. It is likely that users will already have a column named 'id' in their dataframe, and when that's the case, we adjust our index name from 'id' to 'id_0' and if 'id_0' exists, then we use 'id_1' and so forth.

The single "breaking" change here is that DataGrids which did not have an index name set, were rendered with 'index' as the name for their index column, and now they will render with 'id'. If any logic was based on the 'index' column name, it will not work after this update without users updating their code.

EDIT:

We now use "key" as the default index name. Users choose their own index name by passing an optional 'index_name' parameter (not an observable traitlet). If the chosen index name conflicts with an existing column name, the suffix logic detailed above will apply.