### PR TITLE
Fix an issue in 1.1.4 / Release 1.1.5

### DIFF
--- a/ipydatagrid/_version.py
+++ b/ipydatagrid/_version.py
@@ -1,4 +1,4 @@
 # Copyright (c) Bloomberg.
 # Distributed under the terms of the Modified BSD License.
 
-__version__ = "1.1.4"
+__version__ = "1.1.5"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ipydatagrid",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ipydatagrid",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "Fast Datagrid widget for the Jupyter Notebook and JupyterLab",
   "keywords": [
     "jupyter",

--- a/tests/test_datagrid.py
+++ b/tests/test_datagrid.py
@@ -154,6 +154,7 @@ def test_selected_cell_values(monkeypatch, datagrid, dataframe):
 
     assert datagrid.selected_cell_values == [2, 5, 3, 6]
 
+
 def test_dataframe_index_name(dataframe):
     # Setting a custom index name
     dataframe.index.name = "custom_index"
@@ -164,7 +165,8 @@ def test_dataframe_index_name(dataframe):
 
     # Checking index name matches DataFrame retrieved from grid
     data = grid.get_visible_data()
-    assert(data.index.name == "custom_index")
+    assert data.index.name == "custom_index"
+
 
 def test_user_defined_index_name(dataframe):
     # Setting a custom index name
@@ -176,16 +178,15 @@ def test_user_defined_index_name(dataframe):
 
     # Checking index name matches DataFrame retrieved from grid
     index_key = grid.get_dataframe_index(dataframe)
-    data_obj = grid.generate_data_object(
-        dataframe, "ipydguuid", index_key
-    )
+    data_obj = grid.generate_data_object(dataframe, "ipydguuid", index_key)
 
     # Default and unused keys should not be in schema
-    assert "key" not in data_obj['schema']['primaryKey']
-    assert "unused_index" not in data_obj['schema']['primaryKey']
+    assert "key" not in data_obj["schema"]["primaryKey"]
+    assert "unused_index" not in data_obj["schema"]["primaryKey"]
 
     # User defined key should be in primary key schema
-    assert "custom_index" in data_obj['schema']['primaryKey']
+    assert "custom_index" in data_obj["schema"]["primaryKey"]
+
 
 def test_named_dataframe_index(dataframe):
     # Setting a custom index name
@@ -197,15 +198,14 @@ def test_named_dataframe_index(dataframe):
 
     # Generate primary key schema object
     index_key = grid.get_dataframe_index(dataframe)
-    data_obj = grid.generate_data_object(
-        dataframe, "ipydguuid", index_key
-    )
+    data_obj = grid.generate_data_object(dataframe, "ipydguuid", index_key)
 
     # Default and unused keys should not be in schema
-    assert "key" not in data_obj['schema']['primaryKey']
+    assert "key" not in data_obj["schema"]["primaryKey"]
 
     # User named dataframe index should be in schema
-    assert "my_used_index" in data_obj['schema']['primaryKey']
+    assert "my_used_index" in data_obj["schema"]["primaryKey"]
+
 
 def test_default_dataframe_index(dataframe):
     # Setting a custom index name
@@ -216,9 +216,7 @@ def test_default_dataframe_index(dataframe):
 
     # Generate primary key schema object
     index_key = grid.get_dataframe_index(dataframe)
-    data_obj = grid.generate_data_object(
-        dataframe, "ipydguuid", index_key
-    )
+    data_obj = grid.generate_data_object(dataframe, "ipydguuid", index_key)
 
     # Default and unused keys should not be in schema
-    assert "key" in data_obj['schema']['primaryKey']
+    assert "key" in data_obj["schema"]["primaryKey"]

--- a/tests/test_datagrid.py
+++ b/tests/test_datagrid.py
@@ -153,3 +153,72 @@ def test_selected_cell_values(monkeypatch, datagrid, dataframe):
     datagrid.select(1, 0, 2, 1)  # Select 1A to 2B
 
     assert datagrid.selected_cell_values == [2, 5, 3, 6]
+
+def test_dataframe_index_name(dataframe):
+    # Setting a custom index name
+    dataframe.index.name = "custom_index"
+    grid = DataGrid(dataframe)
+
+    # Making sure no value is set for index_name
+    assert grid._index_name is None
+
+    # Checking index name matches DataFrame retrieved from grid
+    data = grid.get_visible_data()
+    assert(data.index.name == "custom_index")
+
+def test_user_defined_index_name(dataframe):
+    # Setting a custom index name
+    dataframe.index.name = "unused_index"
+    grid = DataGrid(dataframe, index_name="custom_index")
+
+    # Making sure index_name is set
+    assert grid._index_name is not None
+
+    # Checking index name matches DataFrame retrieved from grid
+    index_key = grid.get_dataframe_index(dataframe)
+    data_obj = grid.generate_data_object(
+        dataframe, "ipydguuid", index_key
+    )
+
+    # Default and unused keys should not be in schema
+    assert "key" not in data_obj['schema']['primaryKey']
+    assert "unused_index" not in data_obj['schema']['primaryKey']
+
+    # User defined key should be in primary key schema
+    assert "custom_index" in data_obj['schema']['primaryKey']
+
+def test_named_dataframe_index(dataframe):
+    # Setting a custom index name
+    dataframe.index.name = "my_used_index"
+    grid = DataGrid(dataframe)
+
+    # Making sure index_name is set
+    assert grid._index_name is None
+
+    # Generate primary key schema object
+    index_key = grid.get_dataframe_index(dataframe)
+    data_obj = grid.generate_data_object(
+        dataframe, "ipydguuid", index_key
+    )
+
+    # Default and unused keys should not be in schema
+    assert "key" not in data_obj['schema']['primaryKey']
+
+    # User named dataframe index should be in schema
+    assert "my_used_index" in data_obj['schema']['primaryKey']
+
+def test_default_dataframe_index(dataframe):
+    # Setting a custom index name
+    grid = DataGrid(dataframe)
+
+    # Making sure index_name is set
+    assert grid._index_name is None
+
+    # Generate primary key schema object
+    index_key = grid.get_dataframe_index(dataframe)
+    data_obj = grid.generate_data_object(
+        dataframe, "ipydguuid", index_key
+    )
+
+    # Default and unused keys should not be in schema
+    assert "key" in data_obj['schema']['primaryKey']


### PR DESCRIPTION
The logic for index_name in 1.1.4 didn't account for index names of newly passed DataFrames after the grid has been instantiated. This PR adds logic for that and releases 1.1.5 with this fix.