### PR TITLE
Fix for jupyter_client 7

### DIFF
--- a/ipydatagrid/datagrid.py
+++ b/ipydatagrid/datagrid.py
@@ -165,7 +165,7 @@ class SelectionHelper:
 # modified from ipywidgets original
 def _data_to_json(x, obj):
     if isinstance(x, dict):
-        return {k: _data_to_json(v, obj) for k, v in x.items()}
+        return {str(k): _data_to_json(v, obj) for k, v in x.items()}
     elif isinstance(x, (list, tuple)):
         return [_data_to_json(v, obj) for v in x]
     else:


### PR DESCRIPTION
Fixes the data serialization for jupyter_client >=7

This fixes invalid JSON serialization where dictionary keys are not strings