### PR TITLE
Fix rendering

### DIFF
--- a/js/core/viewbasedjsonmodel.ts
+++ b/js/core/viewbasedjsonmodel.ts
@@ -30,8 +30,7 @@ export class ViewBasedJSONModel extends MutableDataModel {
   constructor(data: ViewBasedJSONModel.IData) {
     super();
     this.updateDataset(data);
-    //@ts-ignore
-    window.jsonview = this;
+
     this._transformState = new TransformStateManager();
     // Repaint grid on transform state update
     // Note: This will also result in the `model-reset` signal being sent.

--- a/js/datagrid.ts
+++ b/js/datagrid.ts
@@ -135,17 +135,18 @@ export class DataGridModel extends DOMWidgetModel {
     const schema = Private.createSchema(data);
 
     if (this.data_model) {
-      // Need to update existing ViewBasedJSONModel's dataset attribute
-      // before discarding.
       this.data_model.updateDataset({ data: data.data, schema: schema });
-    } else {
-      this.data_model = new ViewBasedJSONModel({
-        data: data.data,
-        schema: schema,
-      });
-      this.data_model.transformStateChanged.connect(this.syncTransformState);
-      this.data_model.dataSync.connect(this.updateDataSync);
+      this.data_model.transformStateChanged.disconnect(this.syncTransformState);
+      this.data_model.dataSync.disconnect(this.updateDataSync);
     }
+
+    this.data_model = new ViewBasedJSONModel({
+      data: data.data,
+      schema: schema,
+    });
+
+    this.data_model.transformStateChanged.connect(this.syncTransformState);
+    this.data_model.dataSync.connect(this.updateDataSync);
 
     this.updateTransforms();
     this.trigger('data-model-changed');

--- a/tests/js/datagrid.test.ts
+++ b/tests/js/datagrid.test.ts
@@ -31,8 +31,9 @@ describe('Test trait: data', () => {
   test('Comm message sent to backend on frontend cell update', async () => {
     const testData = Private.createBasicTestData();
     const grid = await Private.createGridWidget({ data: testData.set1 });
-    const dataModel = grid.model.data_model;
+    let dataModel = grid.model.data_model;
     grid.model.set('_data', testData.set2);
+    dataModel = grid.model.data_model
     const mock = jest.spyOn(grid.model.comm, 'send');
     dataModel.setData('body', 1, 0, 1.23);
     expect(mock).toBeCalled();


### PR DESCRIPTION
This PR fixes an issue where updating a DataGrid object with a new data model which has a different schema, results in the DataGrid object rendering with the old, incorrect schema. 

