### PR TITLE
Serialization: convert tuples to strings

### DIFF
--- a/ipydatagrid/datagrid.py
+++ b/ipydatagrid/datagrid.py
@@ -167,7 +167,7 @@ def _data_to_json(x, obj):
     if isinstance(x, dict):
         return {str(k): _data_to_json(v, obj) for k, v in x.items()}
     elif isinstance(x, (list, tuple)):
-        return [_data_to_json(v, obj) for v in x]
+        return [_data_to_json(v, str(obj)) for v in x]
     else:
         if isinstance(x, float):
             if np.isnan(x):
@@ -338,7 +338,7 @@ class DataGrid(DOMWidget):
     ).tag(sync=True)
     selections = List(Dict()).tag(sync=True, **widget_serialization)
     editable = Bool(False).tag(sync=True)
-    column_widths = Dict({}).tag(sync=True)
+    column_widths = Dict({}).tag(sync=True, **_data_serialization)
     grid_style = Dict(allow_none=True).tag(sync=True, **widget_serialization)
     auto_fit_columns = Bool(False).tag(sync=True)
     auto_fit_params = Dict(

--- a/tests/test_datagrid.py
+++ b/tests/test_datagrid.py
@@ -220,3 +220,20 @@ def test_default_dataframe_index(dataframe):
 
     # Default and unused keys should not be in schema
     assert "key" in data_obj["schema"]["primaryKey"]
+
+def test_setting_column_widths_on_multiindex_grid():
+    import pandas as pd
+    from ipydatagrid import DataGrid
+
+    col_names = [('Parent Column', 'SubCol 1'), ('Parent Column', 'SubCol 2')]
+    df = pd.DataFrame(data={i: [1, 2, 3] for i in col_names},
+                    columns=col_names)
+
+    grid = DataGrid(df, layout={'height': '200px'})
+    grid
+
+    col_widths = {
+        ('Parent Column', 'SubCol 1'): 100
+    }
+
+    grid.column_widths = col_widths

--- a/tests/test_datagrid.py
+++ b/tests/test_datagrid.py
@@ -221,19 +221,18 @@ def test_default_dataframe_index(dataframe):
     # Default and unused keys should not be in schema
     assert "key" in data_obj["schema"]["primaryKey"]
 
+
 def test_setting_column_widths_on_multiindex_grid():
     import pandas as pd
+
     from ipydatagrid import DataGrid
 
-    col_names = [('Parent Column', 'SubCol 1'), ('Parent Column', 'SubCol 2')]
-    df = pd.DataFrame(data={i: [1, 2, 3] for i in col_names},
-                    columns=col_names)
+    col_names = [("Parent Column", "SubCol 1"), ("Parent Column", "SubCol 2")]
+    df = pd.DataFrame(data={i: [1, 2, 3] for i in col_names}, columns=col_names)
 
-    grid = DataGrid(df, layout={'height': '200px'})
+    grid = DataGrid(df, layout={"height": "200px"})
     grid
 
-    col_widths = {
-        ('Parent Column', 'SubCol 1'): 100
-    }
+    col_widths = {("Parent Column", "SubCol 1"): 100}
 
     grid.column_widths = col_widths


### PR DESCRIPTION
Signed-off-by: Itay Dafna <idafna@seas.upenn.edu>

The following code triggers an exception when jupyter_client>=7 is used:

```python
import pandas as pd
from ipydatagrid import DataGrid

col_names = [('Parent Column', 'SubCol 1'), ('Parent Column', 'SubCol 2')]
df = pd.DataFrame(data={i: [1, 2, 3] for i in col_names},
                  columns=col_names)

grid = DataGrid(df, layout={'height': '200px'})
grid

col_widths = {
    ('Parent Column', 'SubCol 1'): 100
}

grid.column_widths = col_widths
```

This is due to the serialization logic change where tuples are no longer implicitly converted to strings. Similar issue shown in #274 

This PR adds a fix such that tuples passed as traitlet keys in dictionaries are explicitly converted to strings at source.
