### PR TITLE
 Fix for #284 not working in Safari (mac/ios)

### DIFF
--- a/js/vegaexpr.ts
+++ b/js/vegaexpr.ts
@@ -1,16 +1,3 @@
-(((cell.value[1]=='berry')&&(cell.metadata.data['column 1']['key']==11))?'limegreen':'pink') vegaexpr.js:64
-
-(((cell.value[1]=='berry')&&((cell.row, 'column 1')['key']==11))?'limegreen':'pink') vegaexpr.js:70
-
-
-
-
-(((cell.value[1]=='berry')&&(cell.metadata.data['column 1']['key']==11))?'limegreen':'pink') vegaexpr.js:64
-
-(((cell.value[1]=='berry')&&(cell.metadata.data(cell.row, 'column 1')['key']==11))?'limegreen':'pink') vegaexpr.js:73
-
-
-
 // Copyright (c) Bloomberg
 // Distributed under the terms of the Modified BSD License.
 


### PR DESCRIPTION
New PR after I messed up my repo ;)

Describe your changes
Replaced the lookbehind regex in vegaexpr.ts with a normal regex group. Since the resulting matches are anyway re-processed with another regex, the extra capture group in the match shouldn't affect the final result.

Testing performed
Ran python and js tests, confirmed working in jupyter lab in firefox and safari.