### PR TITLE
Handle the missing `IThemeManager` case

### DIFF
--- a/js/plugin.ts
+++ b/js/plugin.ts
@@ -35,12 +35,12 @@ export default datagridPlugin;
 function activateWidgetExtension(
   app: Application<Widget>,
   registry: IJupyterWidgetRegistry,
-  themeManager: IThemeManager,
+  themeManager: IThemeManager | null,
 ): void {
   // Exporting a patched DataGridView widget which handles dynamic theme changes
   class DataGridView extends widgetExports.DataGridView {
     initialize(parameters: WidgetView.IInitializeParameters) {
-      if (themeManager.theme != null) {
+      if (themeManager?.theme != null) {
         this.isLightTheme = themeManager.isLight(themeManager.theme);
       }
       super.initialize(parameters);
@@ -55,7 +55,7 @@ function activateWidgetExtension(
     }
 
     private onThemeChanged() {
-      if (themeManager.theme != null) {
+      if (themeManager?.theme != null) {
         this.isLightTheme = themeManager.isLight(themeManager.theme);
       }
       this.updateGridStyle();


### PR DESCRIPTION
**Describe your changes**
In the `datagridPlugin` plugin, the `IThemeManager` token is optional but in the implementation of the activation function, this token is considered available. This PR handles the case of missing this token.

**Testing performed**
N/A

**Additional context**
This PR will help `ipydatagrid` work with the future version of Voila.
