### PR TITLE
Serialise NumPy arrays as any other array

### DIFF
--- a/ipydatagrid/datagrid.py
+++ b/ipydatagrid/datagrid.py
@@ -165,36 +165,37 @@ class SelectionHelper:
 
 
 # modified from ipywidgets original
-def _data_to_json(x, _obj):
+def _data_to_json(x):
     if isinstance(x, dict):
-        return {str(k): _data_to_json(v, _obj) for k, v in x.items()}
-    elif isinstance(x, (list, tuple)):
-        return [_data_to_json(v, _obj) for v in x]
-    else:
-        if isinstance(x, (float, int)):
-            if np.isnan(x):
-                return "$NaN$"
-            elif np.isposinf(x):
-                return "$Infinity$"
-            elif np.isneginf(x):
-                return "$NegInfinity$"
-            else:
-                return x
-        elif isinstance(x, decimal.Decimal):
-            return str(x)
-        elif isinstance(x, (datetime.datetime, datetime.date)):
-            return x.isoformat()
-        elif x is pd.NaT:
-            return "$NaT$"
-        elif pd.isna(x):
+        return {str(k): _data_to_json(v) for k, v in x.items()}
+    if isinstance(x, np.ndarray):
+        return _data_to_json(x.tolist())
+    if isinstance(x, (list, tuple)):
+        return [_data_to_json(v) for v in x]
+    if isinstance(x, int):
+        return x
+    if isinstance(x, float):
+        if np.isnan(x):
             return "$NaN$"
-        else:
-            return str(x)
+        if np.isposinf(x):
+            return "$Infinity$"
+        if np.isneginf(x):
+            return "$NegInfinity$"
+        return x
+    if isinstance(x, decimal.Decimal):
+        return str(x)
+    if isinstance(x, (datetime.datetime, datetime.date)):
+        return x.isoformat()
+    if x is pd.NaT:
+        return "$NaT$"
+    if pd.isna(x):
+        return "$NaN$"
+    return str(x)
 
 
 _data_serialization = {
     "from_json": widget_serialization["from_json"],
-    "to_json": _data_to_json,
+    "to_json": lambda x, _: _data_to_json(x),  # noqa: U101
 }
 
 

--- a/tests/test_datagrid.py
+++ b/tests/test_datagrid.py
@@ -1,5 +1,6 @@
 import math
 
+import numpy as np
 import pandas as pd
 import pytest
 
@@ -295,9 +296,14 @@ def test_serialization():
                 Decimal(0.00),
                 datetime.date(2022, 8, 19),
                 datetime.datetime.now(),
+                [1, [2, 3], {4: 5}],
+                np.full((2, 3), {"foo": "bar"}),
+                np.full((3, 4, 5), 1.0),
             ]
         }
     )
 
     # Should not raise an error
-    DataGrid(df)
+    dg = DataGrid(df)
+
+    assert dg.data.to_json() == df.to_json()


### PR DESCRIPTION
Signed-off-by: Vasilis Themelis <vdthemelis@gmail.com>

Fixes #393

Allow showing NumPy arrays as normal arrays in the grid. There is no distinction made between normal arrays and NumPy arrays once they are serialised but I assume that this is fine as there is not difference between normal floats and NumPy floats either (say).

Added a small unit test to assert that no exception is thrown when initialising a DataGrid object out of a DataFrame that includes np.array objects of various shapes.

Also:
* Simplify the _data_to_json function in terms of branching;
* Remove unneeded checks for int;
* Eliminate unused argument of _data_to_json;

I also noticed that ipydatagrid flattens arrays before showing them on the grid. I might change that on a separate PR.