### PR TITLE
Major performance improvement

### DIFF
--- a/ipydatagrid/datagrid.py
+++ b/ipydatagrid/datagrid.py
@@ -165,11 +165,11 @@ class SelectionHelper:
 
 
 # modified from ipywidgets original
-def _data_to_json(x, obj):
+def _data_to_json(x, _obj):
     if isinstance(x, dict):
-        return {str(k): _data_to_json(v, obj) for k, v in x.items()}
+        return {str(k): _data_to_json(v, _obj) for k, v in x.items()}
     elif isinstance(x, (list, tuple)):
-        return [_data_to_json(v, str(obj)) for v in x]
+        return [_data_to_json(v, _obj) for v in x]
     else:
         if isinstance(x, (float, int)):
             if np.isnan(x):


### PR DESCRIPTION
The change should be a no-op in terms of what the function that I changed returns. The obj argument of this recursive function is not actually used anywhere --it only appears in the recursive call and not at the base cases.

`str(obj)` is a very expensive operation that we end up needlessly going through for O(rows) operations while initialising a DataGrid.

This change significantly improves performance for me: Initialising a DataGrid for a DataFrame of 30k rows goes from 2.4s to 0.4s.

Signed-off-by: Vasilis Themelis <vdthemelis@gmail.com>