### PR TITLE
fix: do not share the Expr for text_color and background_color

### DIFF
--- a/ipydatagrid/cellrenderer.py
+++ b/ipydatagrid/cellrenderer.py
@@ -6,7 +6,17 @@
 from bqplot import ColorScale, Scale
 from ipywidgets import Color, Widget, widget_serialization
 from py2vega import Variable, py2vega
-from traitlets import Any, Bool, Enum, Float, Instance, Unicode, Union, validate
+from traitlets import (
+    Any,
+    Bool,
+    Enum,
+    Float,
+    Instance,
+    Unicode,
+    Union,
+    default,
+    validate,
+)
 
 from ._frontend import module_name, module_version
 
@@ -68,11 +78,9 @@ class TextRenderer(CellRenderer):
     ).tag(sync=True, **widget_serialization)
     text_color = Union(
         (Color(), Instance(VegaExpr), Instance(ColorScale)),
-        default_value=Expr("default_value"),
     ).tag(sync=True, **widget_serialization)
     background_color = Union(
         (Color(), Instance(VegaExpr), Instance(ColorScale)),
-        default_value=Expr("default_value"),
     ).tag(sync=True, **widget_serialization)
     vertical_alignment = Union(
         (
@@ -97,6 +105,14 @@ class TextRenderer(CellRenderer):
         sync=True
     )
     missing = Unicode("").tag(sync=True)
+
+    @default("text_color")
+    def _default_text_color(self):
+        return Expr("default_value")
+
+    @default("background_color")
+    def _default_background_color(self):
+        return Expr("default_value")
 
 
 class BarRenderer(TextRenderer):


### PR DESCRIPTION
Every TextRenderer shares the same `Expr` (by default). This means that if I create two text renderers, and change the expression on one, it also changes the expression in the other TextRenderer.e.g.

```python

tr1 = TextRenderer()
tr2 = TextRenderer()
tr1.text_color.value = "'red'"
# now tr2.text_color.value is also red, bad UX I think
```

I think this should behave analogous to say a `.layout` widget, where they are not shared.

To be honest, this is not the original reason to create this PR. In solara, we cannot have widgets created at import  time, since each user would share the same widget, which breaks ipydatagrid in solara.

I hope one of the two reasons is compelling enough :)
