### PR TITLE
Add `yarn` to the Binder environment

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -8,5 +8,6 @@ dependencies:
   - nodejs
   - pandas
   - pip
+  - yarn=1
   - pip:
       - ..


### PR DESCRIPTION


**Describe your changes**

Binder appears to be broken at the moment: https://mybinder.org/v2/gh/bloomberg/ipydatagrid/HEAD?urlpath=lab%2Ftree%2Fexamples%2FDataGrid.ipynb

![image](https://user-images.githubusercontent.com/591645/231488374-b9251e8a-7612-43ad-83f3-bf30d2ee6e2d.png)


**Testing performed**

Testing on Binder with this link: https://mybinder.org/v2/gh/jtpio/ipydatagrid/fix-binder

![image](https://user-images.githubusercontent.com/591645/231485557-a494b27e-d71a-43e2-b608-128b4f6f64f0.png)


**Additional context**

