### PR TITLE
Fix cell selection in Jupyter 4.0

### DIFF
--- a/js/mousehandler.ts
+++ b/js/mousehandler.ts
@@ -3,7 +3,6 @@ import {
   CellRenderer,
   DataGrid,
   HyperlinkRenderer,
-  Private,
   TextRenderer,
 } from '@lumino/datagrid';
 import { Platform } from '@lumino/domutils';
@@ -75,7 +74,7 @@ export class MouseHandler extends BasicMouseHandler {
     }
     if (grid) {
       // Create cell config object.
-      const config = Private.createCellConfigObject(grid, hit);
+      const config = MouseHandler.createCellConfigObject(grid, hit);
 
       // Bail if no cell config object is defined for the region.
       if (!config) {
@@ -136,6 +135,34 @@ export class MouseHandler extends BasicMouseHandler {
    */
   get cellClicked(): ISignal<this, DataGrid.HitTestResult> {
     return this._cellClicked;
+  }
+
+  /**
+  * Creates a CellConfig object from a hit region.
+  */
+  private static createCellConfigObject(
+    grid: DataGrid,
+    hit: DataGrid.HitTestResult
+  ): CellRenderer.CellConfig | undefined {
+    const { region, row, column } = hit;
+
+    // Terminate call if region is void.
+    if (region === 'void') {
+      return undefined;
+    }
+
+    // Augment hit region params with value and metadata.
+    const value = grid.dataModel!.data(region, row, column);
+    const metadata = grid.dataModel!.metadata(region, row, column);
+
+    // Create cell config object to retrieve cell renderer.
+    const config = {
+      ...hit,
+      value: value,
+      metadata: metadata
+    } as CellRenderer.CellConfig;
+
+    return config;
   }
 
   private _grid: FeatherGrid;


### PR DESCRIPTION
Fixes https://github.com/bloomberg/ipydatagrid/issues/415

Replaced a call to a private Lumino function that stoped being exported: https://github.com/jupyterlab/lumino/commit/f4feada592291af9e1e3e22313969cbcd724fffd / https://github.com/jupyterlab/lumino/pull/319

The call is replaced with a call to a new copy of the (small) function we were previously calling.

**Testing performed**
Just manual testing of the selection functionality.

**Additional context**
This is the bare minimum required to fix the issue in the description.

There are other issues when switching to JupyterLab 4.0. Would it be worth upgrading the dependencies of this library to Lumino or do we want to keep compatibility with older versions of JupyterLab?

This requires https://github.com/bloomberg/ipydatagrid/pull/419
