### PR TITLE
Implement set_row_value method

### DIFF
--- a/examples/CellEditing.ipynb
+++ b/examples/CellEditing.ipynb
@@ -187,11 +187,27 @@
    "source": [
     "select_all_changed_cells()"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Setting an entire row at once is also possible."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "datagrid.set_row_value(0, [260, \"USA\", 10, \"Very fast car\", 0, \"1999-01-01\", 0, 0, 0])"
+   ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -205,7 +221,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.11.5"
   }
  },
  "nbformat": 4,

--- a/js/datagrid.ts
+++ b/js/datagrid.ts
@@ -93,6 +93,13 @@ export class DataGridModel extends DOMWidgetModel {
           content.value,
         );
       }
+
+      if (content.event_type === 'row-changed') {
+        this.data_model.setRowData(
+          content.row,
+          content.value,
+        );
+      }
     });
   }
 

--- a/tests/js/datagrid.test.ts
+++ b/tests/js/datagrid.test.ts
@@ -97,6 +97,33 @@ describe('Test trait: data', () => {
     });
   });
 
+  test('Backend driven row update propagates properly', async () => {
+    const testData = Private.createBasicTestData();
+    const grid = await Private.createGridWidget({ data: testData.set1 });
+    const row = 1;
+    const value = [1.23];
+    grid.model.set('_data', testData.set2);
+
+    return new Promise<void>((resolve, reject) => {
+      grid.model.data_model.changed.connect(
+        (model: ViewBasedJSONModel, args: any) => {
+          if (args.type === 'cells-changed') {
+            const updatedValue = [model.data(args.region, args.row, 0)];
+            expect(args.row).toBe(row);
+            expect(updatedValue).toStrictEqual(value);
+            resolve();
+          }
+        },
+      );
+
+      emulateCustomCommMessage(grid.model, 'iopub', {
+        event_type: 'row-changed',
+        row: row,
+        value: value,
+      });
+    });
+  });
+
   test('Selection model updated on trait update', async () => {
     const testData = Private.createBasicTestData();
     const grid = await Private.createGridWidget({


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #<number>*

Fix #352

**Describe your changes**

An equivalent to the current `set_cell_value` method, but for setting entire rows.

**Testing performed**

Manual Notebook tests + adding a unit test in JS

**Additional context**

For users, it's more convenient/performant to have this kind of APIs than having to call `set_cell_value` many times. We may want to implement the equivalent for columns at some point.