### PR TITLE
Fixed FeatherGridContextMenu placement in jupyter notebook and voila

### DIFF
--- a/js/core/gridContextMenu.ts
+++ b/js/core/gridContextMenu.ts
@@ -158,8 +158,61 @@ export class FeatherGridContextMenu extends GridContextMenu {
         throw 'unreachable';
     }
 
+    // Get the current height of the main viewport.
+    const px = window.pageXOffset;
+    const py = window.pageYOffset;
+    const cw = document.documentElement.clientWidth;
+    const ch = document.documentElement.clientHeight;
+    const bodyh = document.documentElement.scrollHeight;
+    var style = window.getComputedStyle(document.body);
+    const extraspaceX = parseFloat(style.marginLeft)+parseFloat(style.paddingLeft)+parseFloat(style.borderLeftWidth);
+    const extraspaceY = parseFloat(style.marginTop)+parseFloat(style.paddingTop)+parseFloat(style.borderTopWidth);
+
     // Open context menu at location of the click event
-    this._menu.open(hit.x, hit.y);
+    this._menu.open(hit.x, 0); //Using 0 so it's at least at the bottom
+                               //of the parent div and not a mile down
+
+    // Now that it's open, move it to the correct position.
+    // Lumino won't allow a negative y-coordinate, but we
+    // need it to be negative with absolute positioning. This
+    // position-reposition thing isn't ideal, since there's a
+    // split-second that the menu is not where it ought to be,
+    // but in practice this is usually going to be so brief a
+    // moment that nobody will notice; it's functionally a
+    // performance hit in a spot where people likely won't notice
+    // a performance hit.
+
+    // We're going to do the full coordinate recalculation,
+    // since the conditions below are part of the Lumino
+    // menu's positioning math for a reason. They show up in
+    // ipydatagrid's InteractiveFilterDialog positioning math
+    // as well.
+
+    let node = this._menu.node;
+    let { width, height } = node.getBoundingClientRect();
+
+    let hitx = hit.x;
+    let hity = hit.y;
+
+    // Adjust the X position of the menu to fit on-screen.
+    if (hitx + width > px + cw) {
+      hitx = px + cw - width;
+    }
+
+    // Adjust the Y position of the menu to fit on-screen.
+    if (hity + height > py + ch) {
+      if (hity > py + ch) {
+        hity = py + ch - height;
+      } else {
+        hity = hity - height;
+      }
+    }
+
+    hitx = hitx - extraspaceX;
+    hity = hity - bodyh + extraspaceY;
+
+    // Update the position of the menu to the computed position.
+    this._menu.node.style.transform = `translate(${Math.max(0, hitx)}px, ${hity}px`;
   }
 }
 


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #422*

**Describe your changes**
Added a section of code that repositions the FeatherGridContextMenu widget to the actual click location, using the geometry of the page and document body. This fixes the bug in [https://github.com/bloomberg/ipydatagrid/issues/422](https://github.com/bloomberg/ipydatagrid/issues/422) (and also the original bug, documented in [https://github.com/voila-dashboards/voila/issues/930](https://github.com/voila-dashboards/voila/issues/930)), which is caused by changes in Lumino originally proposed in [https://github.com/jupyterlab/lumino/issues/329#issuecomment-1266200387](https://github.com/jupyterlab/lumino/issues/329#issuecomment-1266200387), along with the retention of absolute positioning for this element in ipydatagrid. 

**Testing performed**
Tested in two different notebooks (one bare-bones/MWE and one full-featured from a production setting) in jupyter notebook and voila (see attached image for example from barebones notebook). If page content changes immediately as a result of opening the filter dialog (such as an output widget getting cleared), this will cause the context menu to appear out of position. This could potentially be remedied by repositioning the menu a _second_ time after the menu is fully opened, but this is likely to be excessive and not a good solution to that particular problem. 

![image](https://github.com/bloomberg/ipydatagrid/assets/14878016/2d6bbd6a-fe8c-49d7-9602-07461559fcce)

In the future, a departure from absolute positioning may be required, which may obviate the need for a repositioning operation here.