### PR TITLE
Update Python versions used in CI

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.12'
       - uses: pre-commit/action@v3.0.0
 
   test:
@@ -32,18 +32,18 @@ jobs:
       fail-fast: false
       matrix:
         py:
+          - '3.12'
           - '3.11'
           - '3.10'
           - '3.9'
           - '3.8'
-          - '3.7'
-          - pypy3.7
+          - pypy3.9
     steps:
       - uses: actions/checkout@v4
       - name: setup python for tox
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.12'
       - name: install tox
         run: python -m pip install tox
       - name: setup python for test ${{ matrix.py }}
@@ -76,10 +76,10 @@ jobs:
           - dev
     steps:
       - uses: actions/checkout@v4
-      - name: setup Python 3.11
+      - name: setup Python 3.12
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.12'
       - name: install tox
         run: python -m pip install tox
       - name: run check for ${{ matrix.tox_env }}
@@ -93,7 +93,7 @@ jobs:
       - name: setup python to build package
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.12'
       - name: install build
         run: python -m pip install build
       - uses: actions/checkout@v4
@@ -112,7 +112,7 @@ jobs:
       - name: setup python to build package
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.12'
       - name: install build
         run: python -m pip install build
       - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ keywords = [
 authors = [
     { name = "Bloomberg" },
 ]
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 classifiers = [
   "Framework :: Jupyter",
   "Intended Audience :: Developers",
@@ -26,16 +26,16 @@ classifiers = [
   "License :: OSI Approved :: BSD License",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.7",
   "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
   "bqplot>=0.11.6",
   "ipywidgets<9,>=7.6",
-  "pandas>=1.3.5", # 1.3.5 is the last version supporting 3.7
+  "pandas>=1.3.5",
   "py2vega>=0.5",
 ]
 optional-dependencies.test = [

--- a/tox.ini
+++ b/tox.ini
@@ -3,11 +3,11 @@ requires =
     tox>=4.2
 env_list =
     fix
+    py312
     py311
     py310
     py39
     py38
-    py37
     pypy3
     docs
     pkg_desc


### PR DESCRIPTION
This PR updates the Python versions used in CI. Summary of changes:

1. Updated latest CPython version from 3.11 to 3.12. The project builds and tests pass locally for me using Python 3.12 on Ubuntu.
2. Where only a single Python version is required for a CI job, increase it from 3.11 to 3.12.
3. Remove Python 3.7 so that the minimum version supported is 3.8. This follows https://devguide.python.org/versions/ which shows that we are now beyond the end of Python 3.7's supported life.
4. Update version of PyPy from 3.7 to 3.9. This is the version of PyPy supported by the current NumPy release (https://pypi.org/project/numpy/1.26.4/#files).