### PR TITLE
Use sensible defaults for BarRenderer.bar_value

### DIFF
--- a/examples/ConditionalFormatting.ipynb
+++ b/examples/ConditionalFormatting.ipynb
@@ -340,7 +340,7 @@
     "renderers = {\n",
     "    \"Value 1\": text_renderer,\n",
     "    \"Dates\": BarRenderer(\n",
-    "        bar_value=DateScale(min=df[\"Dates\"][0], max=df[\"Dates\"][n - 1]),\n",
+    "        bar_value=DateScale(),\n",
     "        bar_color=Expr(bar_color),\n",
     "        format=\"%Y/%m/%d\",\n",
     "        format_type=\"time\",\n",

--- a/examples/Pandas.ipynb
+++ b/examples/Pandas.ipynb
@@ -47,7 +47,7 @@
     "    \"Value 1\": text_renderer,\n",
     "    \"Value 2\": text_renderer,\n",
     "    \"Dates\": BarRenderer(\n",
-    "        bar_value=DateScale(min=df[\"Dates\"][0], max=df[\"Dates\"][n - 1]),\n",
+    "        bar_value=DateScale(),\n",
     "        bar_color=Expr(bar_color),\n",
     "        format=\"%Y/%m/%d\",\n",
     "        format_type=\"time\",\n",

--- a/ipydatagrid/cellrenderer.py
+++ b/ipydatagrid/cellrenderer.py
@@ -120,7 +120,8 @@ class BarRenderer(TextRenderer):
     _view_name = Unicode("BarRendererView").tag(sync=True)
 
     bar_value = Union(
-        (Float(), Instance(VegaExpr), Instance(Scale)), default_value=0.0
+        (Float(allow_none=True), Instance(VegaExpr), Instance(Scale)),
+        default_value=0.0,
     ).tag(sync=True, **widget_serialization)
     bar_color = Union(
         (Color(), Instance(VegaExpr), Instance(ColorScale)),

--- a/ui-tests-ipw7/tests/notebooks/conditional_formatting.ipynb
+++ b/ui-tests-ipw7/tests/notebooks/conditional_formatting.ipynb
@@ -291,7 +291,7 @@
     "renderers = {\n",
     "    \"Value 1\": text_renderer,\n",
     "    \"Dates\": BarRenderer(\n",
-    "        bar_value=DateScale(min=df[\"Dates\"][0], max=df[\"Dates\"][n - 1]),\n",
+    "        bar_value=DateScale(),\n",
     "        bar_color=Expr(bar_color),\n",
     "        format=\"%Y/%m/%d\",\n",
     "        format_type=\"time\",\n",

--- a/ui-tests-ipw7/tests/notebooks/datagrid.ipynb
+++ b/ui-tests-ipw7/tests/notebooks/datagrid.ipynb
@@ -42,7 +42,7 @@
     "    \"Value 1\": text_renderer,\n",
     "    \"Value 2\": text_renderer,\n",
     "    \"Dates\": BarRenderer(\n",
-    "        bar_value=DateScale(min=df[\"Dates\"][0], max=df[\"Dates\"][n - 1]),\n",
+    "        bar_value=DateScale(),\n",
     "        bar_color=Expr(bar_color),\n",
     "        format=\"%Y/%m/%d\",\n",
     "        format_type=\"time\",\n",

--- a/ui-tests-ipw8/tests/notebooks/conditional_formatting.ipynb
+++ b/ui-tests-ipw8/tests/notebooks/conditional_formatting.ipynb
@@ -291,7 +291,7 @@
     "renderers = {\n",
     "    \"Value 1\": text_renderer,\n",
     "    \"Dates\": BarRenderer(\n",
-    "        bar_value=DateScale(min=df[\"Dates\"][0], max=df[\"Dates\"][n - 1]),\n",
+    "        bar_value=DateScale(),\n",
     "        bar_color=Expr(bar_color),\n",
     "        format=\"%Y/%m/%d\",\n",
     "        format_type=\"time\",\n",

--- a/ui-tests-ipw8/tests/notebooks/datagrid.ipynb
+++ b/ui-tests-ipw8/tests/notebooks/datagrid.ipynb
@@ -42,7 +42,7 @@
     "    \"Value 1\": text_renderer,\n",
     "    \"Value 2\": text_renderer,\n",
     "    \"Dates\": BarRenderer(\n",
-    "        bar_value=DateScale(min=df[\"Dates\"][0], max=df[\"Dates\"][n - 1]),\n",
+    "        bar_value=DateScale(),\n",
     "        bar_color=Expr(bar_color),\n",
     "        format=\"%Y/%m/%d\",\n",
     "        format_type=\"time\",\n",


### PR DESCRIPTION
**Describe your changes**

This PR adds some sensible defaults for scales used in `BarRenderer.bar_value` so that they can be omitted by the user. If `min` or `max` arguments of a `DateScale`, `LinearScale` or `LogScale` are omitted, they are determined from the data in the corresponding column. An example from some of the example notebooks is that the previous use of
```python
BarRenderer(bar_value=DateScale(min=df[\"Dates\"][0], max=df[\"Dates\"][n - 1]))
```
can be replaced by
```python
BarRenderer(bar_value=DateScale())
```
The calculations occur in the `DataGrid` constructor on the Python side.

Also, `bar_value` now accepts `None` and will create either a `DateScale` or `LinearScale` depending on the data type of the corresponding column. `bar_value` already has a default of `0.0` and we cannot change this default without causing a backwards incompatibility, hence the use of `None`.

This new functionality is not supported in `default_renderer`, `header_renderer`, or `corner_renderer` as they are not attached to a particular data column.

**Testing performed**

- Manual testing locally.
- New python test `test_bar_renderer_defaults` added.
- Playwright tests include notebook changes to demonstrate the new functionality in the frontend.

**Possible future work**

This work could be extended to cover other `Renderer` classes, and renderers that refer to multiple columns (e.g. `default_renderer`.