### PR TITLE
Correct jlpm watch command

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,16 @@ jupyter labextension develop . --overwrite
 
 Note for developers: the `--symlink` argument on Linux or OS X allows one to modify the JavaScript code in-place. This feature is not available with Windows.
 
+If you are changing TypeScript code you can watch for code changes and automatically rebuild using
+```bash
+jlpm watch
+```
+in one terminal and
+```bash
+jupyter lab
+```
+(or `jupyter notebook` or similar) in another.
+
 ## Contributions
 
 We :heart: contributions.

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "lint": "eslint 'js/**/*.{js,ts}' --quiet --fix",
     "prepack": "jlpm run build:labextension && jlpm run build:nbextension",
     "test": "jest --verbose",
-    "watch": "npm-run-all -p watch:*",
+    "watch": "npm-run-all -p watch:lib watch:labextension watch:nbextension",
     "watch:lib": "tsc -w",
     "watch:nbextension": "webpack --watch",
     "watch:labextension": "jupyter labextension watch ."


### PR DESCRIPTION
This corrects the `jlpm watch` command used by developers to watch for code changes and automatically rebuild, and adds some extra documentation in the README describing its use.

Thanks to @gjmooney for explaining this to me.