### PR TITLE
Add hide column option to context menu

### DIFF
--- a/js/core/gridContextMenu.ts
+++ b/js/core/gridContextMenu.ts
@@ -98,6 +98,13 @@ export class FeatherGridContextMenu extends GridContextMenu {
     switch (hit.region) {
       case 'column-header':
         this._menu.addItem({
+          command: FeatherGridContextMenu.CommandID.HideColumn,
+          args: args,
+        });
+        this._menu.addItem({
+          type: 'separator',
+        });
+        this._menu.addItem({
           command: FeatherGridContextMenu.CommandID.SortAscending,
           args: args,
         });
@@ -141,6 +148,17 @@ export class FeatherGridContextMenu extends GridContextMenu {
         });
         break;
       case 'corner-header':
+        this._menu.addItem({
+          command: FeatherGridContextMenu.CommandID.ShowAllColumns,
+          args: args,
+        });
+        this._menu.addItem({
+          command: FeatherGridContextMenu.CommandID.HideAllColumns,
+          args: args,
+        });
+        this._menu.addItem({
+          type: 'separator',
+        });
         this._menu.addItem({
           command: FeatherGridContextMenu.CommandID.SortAscending,
           args: args,
@@ -246,6 +264,9 @@ export namespace FeatherGridContextMenu {
     SaveSelectionAsCsv = 'saveSelectionAsCsv',
     SaveAllAsCsv = 'saveAllAsCsv',
     ClearSelection = 'clearSelection',
+    HideColumn = 'hideColumn',
+    HideAllColumns = 'hideAllColumns',
+    ShowAllColumns = 'showAllColumns',
   }
 
   /**

--- a/js/core/transform.ts
+++ b/js/core/transform.ts
@@ -2,7 +2,10 @@
  * A declarative spec for specifying transformations.
  */
 export namespace Transform {
-  export type TransformSpec = Transform.Sort | Transform.Filter;
+  export type TransformSpec =
+    | Transform.Sort
+    | Transform.Filter
+    | Transform.Hide;
 
   /**
    * A declarative spec for the `Sort` transformation.
@@ -22,6 +25,26 @@ export namespace Transform {
      * Indicates if the sort should be performed descending or ascending.
      */
     desc: boolean;
+  };
+
+  /**
+   * A declarative spec for the `Hide` transformation.
+   */
+  export type Hide = {
+    /**
+     * A type alias for this trasformation.
+     */
+    type: 'hide';
+
+    /**
+     * The column in the data schema to apply the transformation to.
+     */
+    columnIndex: number;
+
+    /**
+     * Boolean indicating if all columns should be hidden
+     */
+    hideAll: boolean;
   };
 
   /**

--- a/js/core/transformExecutors.ts
+++ b/js/core/transformExecutors.ts
@@ -1,7 +1,7 @@
 import { Dict } from '@jupyter-widgets/base';
 
-import { Transform } from './transform';
 import { DataSource } from '../datasource';
+import { Transform } from './transform';
 
 import * as moment from 'moment';
 
@@ -23,6 +23,52 @@ export namespace TransformExecutor {
    * A read only type for the input/output of .apply().
    */
   export type IData = Readonly<DataSource>;
+}
+
+export class HideExecutor extends TransformExecutor {
+  constructor(options: HideExecutor.IOptions) {
+    super();
+    this._options = options;
+  }
+
+  // input has data and schema
+  public apply(input: TransformExecutor.IData): TransformExecutor.IData {
+    const newSchema = { ...input.schema };
+
+    if (this._options.hideAll) {
+      newSchema.fields = newSchema.fields.filter(
+        (field) => field.name === 'key',
+      );
+    } else {
+      newSchema.fields = newSchema.fields.filter(
+        (field) => field.name !== this._options.field,
+      );
+    }
+
+    return new DataSource(input.data, input.fields, newSchema);
+  }
+
+  protected _options: HideExecutor.IOptions;
+}
+
+/**
+ * The namespace for the `HideExecutor` class statics.
+ */
+export namespace HideExecutor {
+  /**
+   * An options object for initializing a Hide.
+   */
+  export interface IOptions {
+    /**
+     * The name of the field to hide in the data source.
+     */
+    field: string;
+
+    /**
+     * Boolean indicating if all columns should be hidden
+     */
+    hideAll: boolean;
+  }
 }
 
 /**

--- a/js/core/transformStateManager.ts
+++ b/js/core/transformStateManager.ts
@@ -3,8 +3,9 @@ import { Transform } from './transform';
 import { View } from './view';
 
 import {
-  SortExecutor,
   FilterExecutor,
+  HideExecutor,
+  SortExecutor,
   TransformExecutor,
 } from './transformExecutors';
 
@@ -12,7 +13,7 @@ import { each } from '@lumino/algorithm';
 
 import { JSONExt } from '@lumino/coreutils';
 
-import { Signal, ISignal } from '@lumino/signaling';
+import { ISignal, Signal } from '@lumino/signaling';
 import { DataSource } from '../datasource';
 
 /**
@@ -25,6 +26,7 @@ export class TransformStateManager {
       this._state[transform.columnIndex] = {
         sort: undefined,
         filter: undefined,
+        hide: undefined,
       };
     }
 
@@ -40,6 +42,9 @@ export class TransformStateManager {
         break;
       case 'filter':
         this._state[transform.columnIndex]['filter'] = transform;
+        break;
+      case 'hide':
+        this._state[transform.columnIndex]['hide'] = transform;
         break;
       default:
         throw 'unreachable';
@@ -110,6 +115,7 @@ export class TransformStateManager {
   private _createExecutors(data: Readonly<DataSource>): TransformExecutor[] {
     const sortExecutors: SortExecutor[] = [];
     const filterExecutors: FilterExecutor[] = [];
+    const hideExecutors: HideExecutor[] = [];
 
     Object.keys(this._state).forEach((columnIndex) => {
       const transform: TransformStateManager.IColumn = this._state[columnIndex];
@@ -131,10 +137,17 @@ export class TransformStateManager {
         });
         filterExecutors.push(executor);
       }
+      if (transform.hide) {
+        const executor = new HideExecutor({
+          field: data.schema.fields[transform.hide.columnIndex]['name'],
+          hideAll: transform.hide.hideAll,
+        });
+        hideExecutors.push(executor);
+      }
     });
 
     // Always put filters first
-    return [...filterExecutors, ...sortExecutors];
+    return [...filterExecutors, ...sortExecutors, ...hideExecutors];
   }
 
   /**
@@ -156,10 +169,12 @@ export class TransformStateManager {
         columnState.sort = undefined;
       } else if (transformType === 'filter') {
         columnState.filter = undefined;
+      } else if (transformType === 'hide') {
+        columnState.hide = undefined;
       } else {
         throw 'unreachable';
       }
-      if (!columnState.sort && !columnState.filter) {
+      if (!columnState.sort && !columnState.filter && !columnState.hide) {
         delete this._state[columnIndex];
       }
       this._changed.emit({
@@ -214,6 +229,9 @@ export class TransformStateManager {
       if (this._state[column].filter) {
         transforms.push(this._state[column].filter!);
       }
+      if (this._state[column].hide) {
+        transforms.push(this._state[column].hide!);
+      }
     });
     return transforms;
   }
@@ -240,6 +258,7 @@ export namespace TransformStateManager {
   export interface IColumn {
     filter: Transform.Filter | undefined;
     sort: Transform.Sort | undefined;
+    hide: Transform.Hide | undefined;
   }
   export interface IState {
     [key: string]: IColumn;

--- a/js/core/view.ts
+++ b/js/core/view.ts
@@ -42,6 +42,7 @@ export class View {
     if (region === 'body') {
       return this._data.length;
     } else {
+      // If there are no body rows, return one for the header row
       return this._bodyFields[0]?.rows.length ?? 1;
     }
   }

--- a/js/core/viewbasedjsonmodel.ts
+++ b/js/core/viewbasedjsonmodel.ts
@@ -10,8 +10,8 @@ import { View } from './view';
 
 import { TransformStateManager } from './transformStateManager';
 
-import { ArrayUtils } from '../utils';
 import { DataSource } from '../datasource';
+import { ArrayUtils } from '../utils';
 
 /**
  * A view based data model implementation for in-memory JSON data.
@@ -76,6 +76,7 @@ export class ViewBasedJSONModel extends MutableDataModel {
    */
   updateDataset(data: DataSource): void {
     this._dataset = data;
+    // does not happen when selecting hide column
     this._updatePrimaryKeyMap();
     const view = new View(this._dataset);
     this.currentView = view;
@@ -569,6 +570,7 @@ export class ViewBasedJSONModel extends MutableDataModel {
     }
     // We need to rerun the transforms, as the changed cells may change the order
     // or visibility of other rows
+    console.log('update row value');
     this.currentView = this._transformState.createView(this._dataset);
   }
 

--- a/js/feathergrid.ts
+++ b/js/feathergrid.ts
@@ -1034,6 +1034,57 @@ export class FeatherGrid extends Widget {
         this.grid.selectionModel?.clear();
       },
     });
+    commands.addCommand(FeatherGridContextMenu.CommandID.HideColumn, {
+      label: 'Hide Column',
+      mnemonic: -1,
+      execute: (args) => {
+        const cellClick: FeatherGridContextMenu.CommandArgs =
+          args as FeatherGridContextMenu.CommandArgs;
+        const colIndex = this._dataModel.getSchemaIndex(
+          cellClick.region,
+          cellClick.columnIndex,
+        );
+        this._dataModel.addTransform({
+          type: 'hide',
+          columnIndex: colIndex,
+          hideAll: false,
+        });
+      },
+    });
+    commands.addCommand(FeatherGridContextMenu.CommandID.HideAllColumns, {
+      label: 'Hide All Columns',
+      mnemonic: -1,
+      execute: (args) => {
+        const cellClick: FeatherGridContextMenu.CommandArgs =
+          args as FeatherGridContextMenu.CommandArgs;
+        const colIndex = this._dataModel.getSchemaIndex(
+          cellClick.region,
+          cellClick.columnIndex,
+        );
+        this._dataModel.addTransform({
+          type: 'hide',
+          columnIndex: colIndex,
+          hideAll: true,
+        });
+      },
+    });
+    commands.addCommand(FeatherGridContextMenu.CommandID.ShowAllColumns, {
+      label: 'Show All Columns',
+      mnemonic: -1,
+      execute: () => {
+        const activeTransforms: Transform.TransformSpec[] =
+          this._dataModel.activeTransforms;
+        console.log(
+          'this._dataModel.activeTransforms',
+          this._dataModel.activeTransforms,
+        );
+        const newTransforms = activeTransforms.filter(
+          (val) => val.type !== 'hide',
+        );
+        console.log('newTransforms', newTransforms);
+        this._dataModel.replaceTransforms(newTransforms);
+      },
+    });
 
     return commands;
   }


### PR DESCRIPTION
Add 'Hide Column' option to column context menu. 

* Can hide all columns
* Can hide one column
* Can show all hidden columns

Issues:
Hiding a second column has some issues, this is because the column index that comes from the Hit Test result on a mouse click appears to be calculated based on the displayed grid, and the transforms are applied based on column index. So if you hide the original first column, the second column becomes the 'new' first column, and when you try to hide that 'new' column 1, index 1 already has a transform applied and nothing happens. 
