### PR TITLE
Support 'zebra stripes' for rows or columns

### DIFF
--- a/ipydatagrid/datagrid.py
+++ b/ipydatagrid/datagrid.py
@@ -321,10 +321,10 @@ class DataGrid(DOMWidget):
     index_name : str (default: "key")
         String to specify the index column name. **Only set when the grid
         is constructed and is not an observable traitlet**
-    zebra_rows : bool (default: False)
-        Enable "zebra striping" of the grid rows.
-    zebra_columns : bool (default: False)
-        Enable "zebra striping" of the grid columns.
+    horizontal_stripes : bool (default: False)
+        Enable themed coloring of alternate grid rows
+    vertical_stripes : bool (default: False)
+        Enable themed coloring of alternate grid columns
 
     Accessors (not observable traitlets)
     ---------
@@ -416,8 +416,8 @@ class DataGrid(DOMWidget):
     auto_fit_params = Dict(
         {"area": "all", "padding": 30, "numCols": None}, allow_none=False
     ).tag(sync=True)
-    zebra_rows = Bool(False).tag(sync=True)
-    zebra_columns = Bool(False).tag(sync=True)
+    horizontal_stripes = Bool(False).tag(sync=True)
+    vertical_stripes = Bool(False).tag(sync=True)
 
     def __init__(self, dataframe, index_name=None, **kwargs):
         # Setting default index name if not explicitly

--- a/ipydatagrid/datagrid.py
+++ b/ipydatagrid/datagrid.py
@@ -321,6 +321,10 @@ class DataGrid(DOMWidget):
     index_name : str (default: "key")
         String to specify the index column name. **Only set when the grid
         is constructed and is not an observable traitlet**
+    zebra_rows : bool (default: False)
+        Enable "zebra striping" of the grid rows.
+    zebra_columns : bool (default: False)
+        Enable "zebra striping" of the grid columns.
 
     Accessors (not observable traitlets)
     ---------
@@ -412,6 +416,8 @@ class DataGrid(DOMWidget):
     auto_fit_params = Dict(
         {"area": "all", "padding": 30, "numCols": None}, allow_none=False
     ).tag(sync=True)
+    zebra_rows = Bool(False).tag(sync=True)
+    zebra_columns = Bool(False).tag(sync=True)
 
     def __init__(self, dataframe, index_name=None, **kwargs):
         # Setting default index name if not explicitly

--- a/js/datagrid.ts
+++ b/js/datagrid.ts
@@ -122,8 +122,8 @@ export class DataGridModel extends DOMWidgetModel {
       grid_style: {},
       editable: false,
       column_widths: {},
-      zebra_rows: false,
-      zebra_columns: false,
+      horizontal_stripes: false,
+      vertical_stripes: false,
     };
   }
 
@@ -458,8 +458,8 @@ export class DataGridView extends DOMWidgetView {
     });
 
     const grid_style = this.model.get('grid_style');
-    if (this.model.get('zebra_rows') || this.model.get('zebra_columns')) {
-      const index = this.model.get('zebra_rows')
+    if (this.model.get('horizontal_stripes') || this.model.get('vertical_stripes')) {
+      const index = this.model.get('horizontal_stripes')
         ? 'rowBackgroundColor'
         : 'columnBackgroundColor';
       grid_style[index] = (index: number): string => {
@@ -796,8 +796,8 @@ export class DataGridView extends DOMWidgetView {
   model: DataGridModel;
   backboneModel: DataGridModel;
 
-  zebra_rows: boolean;
-  zebra_columns: boolean;
+  horizontal_stripes: boolean;
+  vertical_stripes: boolean;
 
   // keep undefined since widget initializes before constructor
   private _isLightTheme: boolean;

--- a/js/datagrid.ts
+++ b/js/datagrid.ts
@@ -122,6 +122,8 @@ export class DataGridModel extends DOMWidgetModel {
       grid_style: {},
       editable: false,
       column_widths: {},
+      zebra_rows: false,
+      zebra_columns: false,
     };
   }
 
@@ -455,6 +457,18 @@ export class DataGridView extends DOMWidgetView {
       window.removeEventListener('resize', this.manageResizeEvent);
     });
 
+    const grid_style = this.model.get('grid_style');
+    if (this.model.get('zebra_rows') || this.model.get('zebra_columns')) {
+      const index = this.model.get('zebra_rows')
+        ? 'rowBackgroundColor'
+        : 'columnBackgroundColor';
+      grid_style[index] = (index: number): string => {
+        return index % 2 === 0
+          ? Theme.getBackgroundColor(1)
+          : Theme.getBackgroundColor(2);
+      };
+    }
+
     this.grid = new FeatherGrid({
       defaultSizes: {
         rowHeight: this.model.get('base_row_size'),
@@ -463,7 +477,7 @@ export class DataGridView extends DOMWidgetView {
         columnHeaderHeight: this.model.get('base_column_header_size'),
       },
       headerVisibility: this.model.get('header_visibility'),
-      style: this.model.get('grid_style'),
+      style: grid_style,
     });
 
     this.grid.columnWidths = this.model.get('column_widths');
@@ -781,6 +795,9 @@ export class DataGridView extends DOMWidgetView {
   luminoWidget: JupyterLuminoPanelWidget;
   model: DataGridModel;
   backboneModel: DataGridModel;
+
+  zebra_rows: boolean;
+  zebra_columns: boolean;
 
   // keep undefined since widget initializes before constructor
   private _isLightTheme: boolean;


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #379*

**Describe your changes**
I've tried to tackle the issue by leveraging the DataGrid `rowBackgroundColor`/`columnBackgroundColor` functionality.

**Testing performed**
I've tested locally spinning up a Jupyter lab per the instructions in the README.

**Additional context**
rows:
![image](https://github.com/bloomberg/ipydatagrid/assets/80677094/7b53c8ac-d190-406c-8435-04a6f32efe29)
columns:
![image](https://github.com/bloomberg/ipydatagrid/assets/80677094/913726e4-5029-492d-8d7d-8c092e6f5fc8)
dark mode:
![image](https://github.com/bloomberg/ipydatagrid/assets/80677094/e6e44a28-a638-41e7-846b-ea90f029b010)


**Note:** The "zebra striping" terminology comes from the underlying DataGrid, I don't know if there is a better name for it, but I couldn't think of one :)

