### PR TITLE
Fix context menu position on Voila, NbClassic and Notebook<7

### DIFF
--- a/js/core/gridContextMenu.ts
+++ b/js/core/gridContextMenu.ts
@@ -4,7 +4,7 @@ import { DataModel } from '@lumino/datagrid';
 
 import { CommandRegistry } from '@lumino/commands';
 
-import { Menu } from '@lumino/widgets';
+import { Menu, Widget } from '@lumino/widgets';
 
 /**
  * An object which provides context menus for the data grid.
@@ -207,6 +207,15 @@ export class FeatherGridContextMenu extends GridContextMenu {
 
     // Open context menu at location of the click event
     this._menu.open(hit.x, hit.y);
+
+    // Issue 422: menu should be first child of document.body not last child to work on all of
+    // Jupyter Lab, Notebook < 7, NbClassic and Voila. Until this is available in lumino/widgets,
+    // detach and reattach the menu here.
+    const bodyFirstChild = document.body.firstElementChild;
+    if (this._menu.node.parentElement == document.body && bodyFirstChild != this._menu.node) {
+      Widget.detach(this._menu);
+      Widget.attach(this._menu, document.body, bodyFirstChild as HTMLElement);
+    }
   }
 }
 


### PR DESCRIPTION
Fixes issue #422.

The positioning of context menus using Voila, NbClassic and Notebook<7 is incorrect as they are added to the DOM as the last child of the `body` and so the reference element that they are positioned with respect to is not necessarily correct, although it is fine for Jupyter Lab (the most tested option). The solution is make them the first child of the `body` instead.

Longer term there will be an addition to `lumino` so that menus can be attached to the correct node straight away rather than this approach of having to detach and reattach them. This code can remain then as the menu will already be the body's first child at the point of testing so the detach and reattach will be avoided.

Screenshots of this PR working in the presence of scrolling for lab, voila, notebook 6, notebook 7 and nbclassic respectively:

<img width="688" alt="lab" src="https://github.com/bloomberg/ipydatagrid/assets/580326/5851e929-1bd4-4cbf-b04b-c0bd2902b515">
<img width="951" alt="voila" src="https://github.com/bloomberg/ipydatagrid/assets/580326/d4a138dc-0243-4b67-b5ac-8ec00ceefb1d">
<img width="918" alt="notebook6" src="https://github.com/bloomberg/ipydatagrid/assets/580326/63b72353-4c80-4d92-9978-46d12b2855bd">
<img width="906" alt="notebook7" src="https://github.com/bloomberg/ipydatagrid/assets/580326/b21c3755-93d3-41f4-932a-855bad03eb88">
<img width="782" alt="nbclassic" src="https://github.com/bloomberg/ipydatagrid/assets/580326/05f75b32-9234-441f-aacc-be7dfa839455">
