### PR TITLE
🚀 create a `selected_visible_cell_iterator` property

### DIFF
--- a/ipydatagrid/datagrid.py
+++ b/ipydatagrid/datagrid.py
@@ -776,7 +776,9 @@ class DataGrid(DOMWidget):
         view_data_object = self.generate_data_object(
             view_data, "ipydguuid", index_key
         )
-        return SelectionHelper(view_data_object, self.selections, self.selection_mode)
+        return SelectionHelper(
+            view_data_object, self.selections, self.selection_mode
+        )
 
     @property
     def selected_cell_values(self):

--- a/ipydatagrid/datagrid.py
+++ b/ipydatagrid/datagrid.py
@@ -760,11 +760,11 @@ class DataGrid(DOMWidget):
         return SelectionHelper(
             self._data, self.selections, self.selection_mode
         ).all()
-
+        
     @property
-    def selected_cell_values(self):
+    def selected_visible_cell_iterator(self):
         """
-        List of values for all selected cells.
+        An iterator to traverse selected visible cells one by one.
         """
         # Copy of the front-end data model
         view_data = self.get_visible_data()
@@ -776,10 +776,14 @@ class DataGrid(DOMWidget):
         view_data_object = self.generate_data_object(
             view_data, "ipydguuid", index_key
         )
+        return SelectionHelper(view_data_object, self.selections, self.selection_mode)
 
-        return SelectionHelper(
-            view_data_object, self.selections, self.selection_mode
-        ).all_values()
+    @property
+    def selected_cell_values(self):
+        """
+        List of values for all selected cells.
+        """
+        return self.selected_visible_cell_iterator.all_values()
 
     @property
     def selected_cell_iterator(self):

--- a/ipydatagrid/datagrid.py
+++ b/ipydatagrid/datagrid.py
@@ -760,7 +760,7 @@ class DataGrid(DOMWidget):
         return SelectionHelper(
             self._data, self.selections, self.selection_mode
         ).all()
-        
+
     @property
     def selected_visible_cell_iterator(self):
         """


### PR DESCRIPTION
**Describe your changes**
this allows users to use the SelectionHelper on visible data only.
I require this functionality in `ipyautoui` and have previously monkey-patched `DataGrid` to add it - 
in the version bump to >1.3 there have been updates to the SelectionHelper thus breaking my patch - 
I think that the functionality could be useful to others so it would be great to get it supported by the lib.
the update is very simple (see diff) and doesn't represent an additional maintainence burden.

*Issue number of the reported bug or feature request: #340*

**Testing performed**
I monkey-patched DataGrid and added the new features and confirmed it is working. 
I was having trouble setting up the dev env in this repo https://github.com/bloomberg/ipydatagrid/issues/510 so haven't been able to test the full package.

