### PR TITLE
Fix correct display of date-based filter conditions

### DIFF
--- a/js/core/filterMenu.ts
+++ b/js/core/filterMenu.ts
@@ -954,21 +954,21 @@ export class InteractiveFilterDialog extends BoxPanel {
       h.option(
         {
           value: '<=',
-          ...(op === '<' && { selected: '' }),
+          ...(op === '<=' && { selected: '' }),
         },
         'Date is on or before:',
       ),
       h.option(
         {
           value: '>=',
-          ...(op === '>' && { selected: '' }),
+          ...(op === '>=' && { selected: '' }),
         },
         'Date is on or after:',
       ),
       h.option(
         {
           value: 'isOnSameDay',
-          ...(op === 'between' && { selected: '' }),
+          ...(op === 'isOnSameDay' && { selected: '' }),
         },
         'Date is exactly:',
       ),


### PR DESCRIPTION
Fixes #530.

Fixes the correct display of "filter by" conditions for date-based columns selected in the filter menu. The changes are trivial, it looks like it was originally a copy-and-paste error.

Screenshot of the problem is in the associated issue, and here is one after this fix:

[Screencast from 2024-08-02 14-38-08.webm](https://github.com/user-attachments/assets/e361fa14-69e9-48f8-ae87-05a1b61dcf6c)
